### PR TITLE
Geo anal activity tracking

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -137,7 +137,7 @@ kotlin {
 
                 implementation "com.jaredrummler:android-device-names:$deviceNamesVersion"
 
-                //implementation "com.github.fondesa:kpermissions:$kpermissionsVersion"
+                implementation "com.github.fondesa:kpermissions:$kpermissionsVersion"
 
                 //Failed attempt at fixing `Kotlin plugin is applied to the project :app but we
                 // cannot find the KaptTask. Make sure you apply the kotlin-kapt plugin because it

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -131,6 +131,13 @@ kotlin {
                 implementation "androidx.constraintlayout:constraintlayout:$constraintLayoutVersion"
                 implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
                 implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
+                implementation "com.google.android.gms:play-services-location:$playServicesVersion"
+                // Kotlin Anko
+                implementation "org.jetbrains.anko:anko-commons:$ankoVersion"
+
+                implementation "com.jaredrummler:android-device-names:$deviceNamesVersion"
+
+                //implementation "com.github.fondesa:kpermissions:$kpermissionsVersion"
 
                 //Failed attempt at fixing `Kotlin plugin is applied to the project :app but we
                 // cannot find the KaptTask. Make sure you apply the kotlin-kapt plugin because it

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/Platform.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/Platform.kt
@@ -16,33 +16,15 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+expect object Platform {
+    val now: Long
+    val nowString: String
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
-    BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
-    override fun validate(): Boolean {
-        return true
-    }
+    val app_version: String
+    val api_level: Long
+    val device_model: String
+    val language: String
+    val country: String
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
@@ -22,12 +22,32 @@ import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
 import com.ludoscity.herdr.common.data.database.HerdrDatabase
 import com.ludoscity.herdr.common.data.database.dao.AnalTrackingDatapointDao
+import dev.icerock.moko.mvvm.livedata.LiveData
+import dev.icerock.moko.mvvm.livedata.MutableLiveData
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
 class AnalTrackingRepository : KoinComponent {
 
     private val herdrDb: HerdrDatabase by inject()
+
+    private val _hasLocationPermission = MutableLiveData(false)
+    val hasLocationPermission: LiveData<Boolean> = _hasLocationPermission
+
+    fun onLocationPermissionAccepted(): Response<Unit> {
+        _hasLocationPermission.value = true
+        return Response.Success(Unit)
+    }
+
+    fun onLocationPermissionDenied(): Response<Unit> {
+        _hasLocationPermission.value = false
+        return Response.Success(Unit)
+    }
+
+    fun onLocationPermissionPermanentlyDenied(): Response<Unit> {
+        _hasLocationPermission.value = false
+        return Response.Success(Unit)
+    }
 
     suspend fun insertAnalTrackingDatapoint(record: AnalTrackingDatapoint): Response<List<AnalTrackingDatapoint>> {
         val analTrackingDao = AnalTrackingDatapointDao(herdrDb)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -46,6 +46,7 @@ private val coreModule = module {
     single { SaveAnalyticsDatapointUseCaseAsync() }
     single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }
     single { ObserveGeoTrackingUseCaseSync() }
+    single { ObserveLoggedInUseCaseSync() }
     single { UpdateGeoTrackingUseCaseSync() }
 }
 

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -7,7 +7,9 @@ import com.ludoscity.herdr.common.data.network.cozy.CozyCloupApi
 import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
 import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
 import com.ludoscity.herdr.common.data.repository.LoginRepository
+import com.ludoscity.herdr.common.domain.usecase.analytics.GetPermissionGrantedUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
+import com.ludoscity.herdr.common.domain.usecase.analytics.UpdatePermissionGrantedUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeoTrackingDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseSync
@@ -47,6 +49,8 @@ private val coreModule = module {
     single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }
     single { ObserveGeoTrackingUseCaseSync() }
     single { ObserveLoggedInUseCaseSync() }
+    single { UpdatePermissionGrantedUseCaseSync() }
+    single { GetPermissionGrantedUseCaseSync() }
     single { UpdateGeoTrackingUseCaseSync() }
 }
 

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -8,7 +8,10 @@ import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
 import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
 import com.ludoscity.herdr.common.data.repository.LoginRepository
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeotrackingDatapointUseCaseAsync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseSync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeoTrackingDatapointUseCaseAsync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseSync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateUserLocGeoTrackingDatapointUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.login.*
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -39,8 +42,11 @@ private val coreModule = module {
     single { RetrieveAccessAndRefreshTokenUseCaseAsync() }
     single { RefreshAccessAndRefreshTokenUseCaseAsync() }
     single { CreateDirectoryUseCaseAsync() }
-    single { SaveGeotrackingDatapointUseCaseAsync() }
+    single { SaveGeoTrackingDatapointUseCaseAsync() }
     single { SaveAnalyticsDatapointUseCaseAsync() }
+    single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }
+    single { ObserveGeoTrackingUseCaseSync() }
+    single { UpdateGeoTrackingUseCaseSync() }
 }
 
 internal inline fun <reified T> Scope.getWith(vararg params: Any?): T {

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/GetPermissionGrantedUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/GetPermissionGrantedUseCaseSync.kt
@@ -1,0 +1,34 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.analytics
+
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import dev.icerock.moko.mvvm.livedata.LiveData
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class GetPermissionGrantedUseCaseSync : KoinComponent,
+    BaseUseCaseSync<Nothing, LiveData<Boolean>>() {
+    private val repo: AnalTrackingRepository by inject()
+    override fun run(): Response<LiveData<Boolean>> {
+        return Response.Success(repo.hasLocationPermission)
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UpdateLocationPermissionGrantedUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UpdateLocationPermissionGrantedUseCaseInput.kt
@@ -1,0 +1,28 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.analytics
+
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+
+class UpdateLocationPermissionGrantedUseCaseInput(val newState: Boolean) :
+    BaseUseCaseInput {
+    override fun validate(): Boolean {
+        return true
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UpdatePermissionGrantedUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UpdatePermissionGrantedUseCaseSync.kt
@@ -1,0 +1,38 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.analytics
+
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class UpdatePermissionGrantedUseCaseSync : KoinComponent,
+    BaseUseCaseSync<UpdateLocationPermissionGrantedUseCaseInput, Unit>() {
+    private val repo: AnalTrackingRepository by inject()
+    override fun run(): Response<Unit> {
+
+        return if (input?.newState == true) {
+            repo.onLocationPermissionAccepted()
+        } else {
+            repo.onLocationPermissionDenied()
+        }
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/ObserveGeoTrackingUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/ObserveGeoTrackingUseCaseInput.kt
@@ -16,32 +16,12 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
+class ObserveGeoTrackingUseCaseInput(val observer: (Boolean) -> Unit) :
     BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
     override fun validate(): Boolean {
         return true
     }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/ObserveGeoTrackingUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/ObserveGeoTrackingUseCaseSync.kt
@@ -16,33 +16,18 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
-    BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
-    override fun validate(): Boolean {
-        return true
+class ObserveGeoTrackingUseCaseSync : KoinComponent,
+    BaseUseCaseSync<ObserveGeoTrackingUseCaseInput, Unit>() {
+    private val repo: GeoTrackingRepository by inject()
+    override fun run(): Response<Unit> {
+        return repo.addGeoTrackingObserver(input!!.observer)
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/SaveGeoTrackingDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/SaveGeoTrackingDatapointUseCaseAsync.kt
@@ -16,33 +16,19 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
-    BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
-    override fun validate(): Boolean {
-        return true
+class SaveGeoTrackingDatapointUseCaseAsync : KoinComponent,
+    BaseUseCaseAsync<SaveGeoTrackingDatapointUseCaseInput, List<GeoTrackingDatapoint>>() {
+    private val repo: GeoTrackingRepository by inject()
+    override suspend fun run(): Response<List<GeoTrackingDatapoint>> {
+        return repo.insertGeoTrackingDatapoint(input!!.toSave)
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/SaveGeoTrackingDatapointUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/SaveGeoTrackingDatapointUseCaseInput.kt
@@ -18,17 +18,26 @@
 
 package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.Platform
 import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
-import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
-import org.koin.core.KoinComponent
-import org.koin.core.inject
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
 
-class SaveGeotrackingDatapointUseCaseAsync : KoinComponent,
-    BaseUseCaseAsync<SaveGeotrackingDatapointUseCaseInput, List<GeoTrackingDatapoint>>() {
-    private val repo: GeoTrackingRepository by inject()
-    override suspend fun run(): Response<List<GeoTrackingDatapoint>> {
-        return repo.insertGeoTrackingDatapoint(input!!.toSave)
+class SaveGeoTrackingDatapointUseCaseInput(toSave: GeoTrackingDatapoint) :
+    BaseUseCaseInput {
+
+    val toSave:GeoTrackingDatapoint = GeoTrackingDatapoint(
+            -1,
+            Platform.now,
+            toSave.altitude,
+            toSave.accuracy_horizontal_meters,
+            toSave.accuracy_vertical_meters,
+            toSave.latitude,
+            toSave.longitude,
+            0L,
+            Platform.nowString
+    )
+
+    override fun validate(): Boolean {
+        return true
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateGeoTrackingUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateGeoTrackingUseCaseInput.kt
@@ -16,32 +16,12 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
+class UpdateGeoTrackingUseCaseInput(val newState: Boolean) :
     BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
     override fun validate(): Boolean {
         return true
     }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateGeoTrackingUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateGeoTrackingUseCaseSync.kt
@@ -18,12 +18,17 @@
 
 package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
 
-class SaveGeotrackingDatapointUseCaseInput(val toSave: GeoTrackingDatapoint) :
-    BaseUseCaseInput {
-    override fun validate(): Boolean {
-        return true
+class UpdateGeoTrackingUseCaseSync : KoinComponent,
+    BaseUseCaseSync<UpdateGeoTrackingUseCaseInput, Unit>() {
+    private val repo: GeoTrackingRepository by inject()
+    override fun run(): Response<Unit> {
+
+        return repo.updateGeoTracking(input!!.newState)
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateUserLocGeoTrackingDatapointUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UpdateUserLocGeoTrackingDatapointUseCaseSync.kt
@@ -16,33 +16,20 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common.domain.usecase.geotracking
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
 
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
+class UpdateUserLocGeoTrackingDatapointUseCaseSync : KoinComponent,
+    BaseUseCaseSync<SaveGeoTrackingDatapointUseCaseInput, GeoTrackingDatapoint>() {
+    private val repo: GeoTrackingRepository by inject()
+    override fun run(): Response<GeoTrackingDatapoint> {
 
-) :
-    BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
-    override fun validate(): Boolean {
-        return true
+        return repo.onNewUserLocation(input!!.toSave)
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/ObserveLoggedInUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/ObserveLoggedInUseCaseInput.kt
@@ -1,0 +1,28 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.login
+
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+
+class ObserveLoggedInUseCaseInput(val observer: (Boolean?) -> Unit) :
+    BaseUseCaseInput {
+    override fun validate(): Boolean {
+        return true
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/ObserveLoggedInUseCaseSync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/ObserveLoggedInUseCaseSync.kt
@@ -1,0 +1,33 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.login
+
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.LoginRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseSync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class ObserveLoggedInUseCaseSync : KoinComponent,
+    BaseUseCaseSync<ObserveLoggedInUseCaseInput, Unit>() {
+    private val repo: LoginRepository by inject()
+    override fun run(): Response<Unit> {
+        return repo.addLoggedInObserver(input!!.observer)
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/drivelogin/DriveLoginViewModel.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/drivelogin/DriveLoginViewModel.kt
@@ -149,8 +149,10 @@ class DriveLoginViewModel(override val eventsDispatcher: EventsDispatcher<DriveL
     }
 
     private fun processUnregisterResponse(response: Response<Unit>) {
+        log.d { "About to process client unregister response" }
         when (response) {
             is Response.Success -> {
+                log.d { "Posting ErrorAuthClientRegistration" }
                 _authClientRegistrationResult.postValue(
                     ErrorAuthClientRegistration(
                         Response.Error(
@@ -158,6 +160,7 @@ class DriveLoginViewModel(override val eventsDispatcher: EventsDispatcher<DriveL
                         )
                     )
                 )
+                log.d { "Posting ErrorUserCredentials" }
                 _userCredentials.postValue(
                     ErrorUserCredentials(
                         Response.Error(
@@ -167,6 +170,7 @@ class DriveLoginViewModel(override val eventsDispatcher: EventsDispatcher<DriveL
                 )
             }
             else -> {
+                log.d { "Something is wrong. Posting again" }
                 //Something happened down there. Here at model level, simply repost
                 //it does eat the original probably network Error in response
                 _authClientRegistrationResult.postValue(authClientRegistrationResult.value)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/main/HerdrViewModel.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/main/HerdrViewModel.kt
@@ -46,10 +46,10 @@ class HerdrViewModel : KoinComponent, ViewModel() {
 
         if (granted) {
             log.d { "Location permission granted" }
-            saveAnalytics(null, "Location permission granted")
+            //saveAnalytics(null, "Location permission granted")
         } else {
             log.d { "Location permission denied" }
-            saveAnalytics(null, "Location permission denied")
+            //saveAnalytics(null, "Location permission denied")
         }
     }
 
@@ -88,19 +88,5 @@ class HerdrViewModel : KoinComponent, ViewModel() {
     ) {
         val useCaseInput = RetrieveAccessAndRefreshTokenUseCaseInput(true)
         retrieveAccessAndRefreshTokenUseCase.execute(useCaseInput)
-    }
-
-    //FIXME: actual value always being null see
-    // https://github.com/f8full/findmybikes/blob/be3e9504d2441e0c0a661bee88bf6ca7276d2c14/app/src/main/java/com/ludoscity/findmybikes/data/database/tracking/AnalTrackingDatapoint.kt#L47
-    private fun saveAnalytics(
-        batteryChargePercentage: Long? = null,
-        description: String
-    ) = launchSilent(
-        coroutineContext,
-        exceptionHandler, job
-    ) {
-        saveAnaltrackingDatapointUseCaseAsync.execute(
-            SaveAnalyticsDatapointUseCaseInput(batteryChargePercentage, description)
-        )
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/start/StartViewModel.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/start/StartViewModel.kt
@@ -18,61 +18,25 @@
 
 package com.ludoscity.herdr.common.ui.start
 
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
-import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseInput
-import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeotrackingDatapointUseCaseAsync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeotrackingDatapointUseCaseInput
-import com.ludoscity.herdr.common.utils.launchSilent
+import co.touchlab.kermit.Kermit
 import dev.icerock.moko.mvvm.dispatcher.EventsDispatcher
 import dev.icerock.moko.mvvm.dispatcher.EventsDispatcherOwner
 import dev.icerock.moko.mvvm.viewmodel.ViewModel
-import kotlinx.coroutines.CoroutineExceptionHandler
-import kotlinx.coroutines.Job
 import org.koin.core.KoinComponent
 import org.koin.core.inject
-import kotlin.coroutines.CoroutineContext
+import org.koin.core.parameter.parametersOf
 
 class StartViewModel(
     override val eventsDispatcher: EventsDispatcher<StartFragmentEventListener>
 ) : KoinComponent, ViewModel(), EventsDispatcherOwner<StartViewModel.StartFragmentEventListener> {
 
-    private val saveGeotrackingDatapointUseCaseAsync: SaveGeotrackingDatapointUseCaseAsync by inject()
-    private val saveAnaltrackingDatapointUseCaseAsync: SaveAnalyticsDatapointUseCaseAsync by inject()
-
-    // ASYNC - COROUTINES
-    private val coroutineContext: CoroutineContext by inject()
-    private var job: Job = Job()
-    private val exceptionHandler = CoroutineExceptionHandler { _, _ -> }
+    private val log: Kermit by inject { parametersOf("StartViewModel") }
 
     fun onSetupButtonPressed() {
         eventsDispatcher.dispatchEvent { routeToDriveSetup() }
-        //testAddGeolocationRowToDb()
-        //testAddAnalyticsRowToDb()
     }
 
     interface StartFragmentEventListener {
         fun routeToDriveSetup()
-    }
-
-    private fun testAddGeolocationRowToDb() = launchSilent(
-        coroutineContext,
-        exceptionHandler, job
-    ) {
-        val useCaseInput = SaveGeotrackingDatapointUseCaseInput(
-            GeoTrackingDatapoint(-1, 666, null, 66.6, null, 66.6, 66.6, 0, "666")
-        )
-        val response = saveGeotrackingDatapointUseCaseAsync.execute(useCaseInput)
-    }
-
-    private fun testAddAnalyticsRowToDb() = launchSilent(
-        coroutineContext,
-        exceptionHandler, job
-    ) {
-        val useCaseInput = SaveAnalyticsDatapointUseCaseInput(
-            AnalTrackingDatapoint(-1, 666, "666", 66, "666", "666", "666", null, "666", 0, "666")
-        )
-        val response = saveAnaltrackingDatapointUseCaseAsync.execute(useCaseInput)
     }
 }

--- a/app/src/iosMain/kotlin/com/ludoscity/herdr/common/PlatformIos.kt
+++ b/app/src/iosMain/kotlin/com/ludoscity/herdr/common/PlatformIos.kt
@@ -16,33 +16,20 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common.domain.usecase.analytics
+package com.ludoscity.herdr.common
 
-import com.ludoscity.herdr.common.Platform
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
-
-class SaveAnalyticsDatapointUseCaseInput(
-        batteryChargePercentage: Long? = null,
-        description: String
-
-) :
-    BaseUseCaseInput {
-    val toSave: AnalTrackingDatapoint = AnalTrackingDatapoint(
-            -1,
-            Platform.now,
-            Platform.app_version,
-            Platform.api_level,
-            Platform.device_model,
-            Platform.language,
-            Platform.country,
-            batteryChargePercentage,
-            description,
-            0L,
-            Platform.nowString
-    )
-
-    override fun validate(): Boolean {
-        return true
-    }
+actual object Platform {
+    actual val app_version: String = "iOS:"
+    actual val api_level: Long
+        get() = TODO("Not yet implemented")
+    actual val device_model: String
+        get() = TODO("Not yet implemented")
+    actual val language: String
+        get() = TODO("Not yet implemented")
+    actual val country: String
+        get() = TODO("Not yet implemented")
+    actual val now: Long
+        get() = TODO("Not yet implemented")
+    actual val nowString: String
+        get() = TODO("Not yet implemented")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,10 @@
           package="com.ludoscity.herdr">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
 
     <application
             android:allowBackup="true"
@@ -47,6 +51,15 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        <service
+            android:name=".data.transrecognition.TransitionRecognitionIntentService"
+            android:enabled="true"
+            android:exported="false" />
+
+        <service
+            android:name=".data.transrecognition.TransitionRecognitionService"
+            android:enabled="true"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/ludoscity/herdr/common/Platform.kt
+++ b/app/src/main/java/com/ludoscity/herdr/common/Platform.kt
@@ -1,0 +1,42 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common
+
+import android.os.Build
+import com.jaredrummler.android.device.DeviceName
+import com.ludoscity.herdr.BuildConfig
+import com.ludoscity.herdr.utils.Utils
+import java.text.SimpleDateFormat
+import java.util.*
+
+actual object Platform {
+    actual val now: Long
+        get() = System.currentTimeMillis()
+    actual val nowString: String
+        get() = SimpleDateFormat(Utils.getSimpleDateFormatPattern(), Locale.US)
+                .format(Date(System.currentTimeMillis()))
+
+    actual val app_version: String = "Android:${BuildConfig.VERSION_NAME}"
+    actual val api_level: Long = Build.VERSION.SDK_INT.toLong()
+    actual val device_model: String = DeviceName.getDeviceName()
+    actual val language: String
+        get() = Locale.getDefault().language
+    actual val country: String
+        get() = Locale.getDefault().country
+}

--- a/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionIntentService.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionIntentService.kt
@@ -1,0 +1,182 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.data.transrecognition
+
+import android.app.IntentService
+import android.content.Intent
+import android.util.Log
+import com.google.android.gms.location.ActivityTransition
+import com.google.android.gms.location.ActivityTransitionResult
+import com.google.android.gms.location.DetectedActivity
+
+import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
+import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseInput
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseInput
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseSync
+import com.ludoscity.herdr.common.utils.launchSilent
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Job
+import org.jetbrains.anko.runOnUiThread
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created by F8Full on 2019-07-02. This file is part of #findmybikes
+ * Modified by F8Full on 2020-08-02. This file is part of herdr
+ * An intent service class to monitor user activities transitions via activity transition recognition API
+ * https://developer.android.com/guide/topics/location/transitions
+ * The API is passed a pending intent pointing to this service. When an activity transition occurs
+ * onHandleIntent is called, from which transitions can be extracted.
+ */
+class TransitionRecognitionIntentService :
+        IntentService("TransitionRecognitionIntentService"), KoinComponent {
+
+    companion object {
+        private val TAG = TransitionRecognitionIntentService::class.java.simpleName
+    }
+
+    // ASYNC - COROUTINES
+    private val coroutineContext: CoroutineContext by inject()
+    private var job: Job = Job()
+    private val exceptionHandler = CoroutineExceptionHandler { _, _ -> }
+
+    private val saveAnaltrackingDatapointUseCaseAsync:
+            SaveAnalyticsDatapointUseCaseAsync by inject()
+    private val updateGeoTrackingUseCaseSync:
+            UpdateGeoTrackingUseCaseSync by inject()
+
+
+    override fun onHandleIntent(p0: Intent?) {
+        p0?.let { intent ->
+            //TODO: check intent.getAction
+            Log.d("TransitionsIntentServic", "onHandleIntent")
+
+            if (ActivityTransitionResult.hasResult(intent)) {
+                val result = ActivityTransitionResult.extractResult(intent)
+                for (event in result?.transitionEvents ?: emptyList()) {
+                    when (event.activityType) {
+                        DetectedActivity.STILL -> {
+                            Log.d("TransitionsIntentServic", "STILL")
+                            if (event.transitionType == ActivityTransition.ACTIVITY_TRANSITION_ENTER) {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_ENTER")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--STILL-ACTIVITY_TRANSITION_ENTER"
+                                )
+                                runOnUiThread {
+                                    updateGeoTrackingUseCaseSync.execute(
+                                            UpdateGeoTrackingUseCaseInput(false)
+                                    )
+                                }
+                            } else {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_EXIT")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--STILL-ACTIVITY_TRANSITION_EXIT"
+                                )
+                            }
+                        }
+                        DetectedActivity.WALKING -> {
+                            Log.d("TransitionsIntentServic", "WALKING")
+                            if (event.transitionType == ActivityTransition.ACTIVITY_TRANSITION_ENTER) {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_ENTER")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--WALKING-ACTIVITY_TRANSITION_ENTER"
+                                )
+                                runOnUiThread {
+                                    updateGeoTrackingUseCaseSync.execute(
+                                            UpdateGeoTrackingUseCaseInput(true)
+                                    )
+                                }
+                            } else {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_EXIT")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--WALKING-ACTIVITY_TRANSITION_EXIT"
+                                )
+                            }
+                        }
+                        DetectedActivity.RUNNING -> {
+                            Log.d("TransitionsIntentServic", "RUNNING")
+                            if (event.transitionType == ActivityTransition.ACTIVITY_TRANSITION_ENTER) {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_ENTER")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--RUNNING-ACTIVITY_TRANSITION_ENTER"
+                                )
+                                runOnUiThread {
+                                    updateGeoTrackingUseCaseSync.execute(
+                                            UpdateGeoTrackingUseCaseInput(false)
+                                    )
+                                }
+                            } else {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_EXIT")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--WALKING-ACTIVITY_TRANSITION_EXIT"
+                                )
+                            }
+                        }
+                        DetectedActivity.ON_BICYCLE -> {
+                            Log.d("TransitionsIntentServic", "ON_BICYCLE")
+                            if (event.transitionType == ActivityTransition.ACTIVITY_TRANSITION_ENTER) {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_ENTER")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--ON_BICYCLE-ACTIVITY_TRANSITION_ENTER"
+                                )
+                                runOnUiThread {
+                                    updateGeoTrackingUseCaseSync.execute(
+                                            //UpdateGeoTrackingUseCaseInput(true)
+                                            UpdateGeoTrackingUseCaseInput(false)
+                                    )
+                                }
+                            } else {
+                                Log.d("TransitionsIntentServic", "ACTIVITY_TRANSITION_EXIT")
+                                saveAnalytics(
+                                        null,
+                                        "$TAG::onHandleIntent--ON_BICYCLE-ACTIVITY_TRANSITION_EXIT"
+                                )
+                                runOnUiThread {
+                                    updateGeoTrackingUseCaseSync.execute(
+                                            UpdateGeoTrackingUseCaseInput(false)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //FIXME: actual value always being null see
+    // https://github.com/f8full/findmybikes/blob/be3e9504d2441e0c0a661bee88bf6ca7276d2c14/app/src/main/java/com/ludoscity/findmybikes/data/database/tracking/AnalTrackingDatapoint.kt#L47
+    private fun saveAnalytics(batteryChargePercentage: Long? = null,
+                              description: String) = launchSilent(
+            coroutineContext,
+            exceptionHandler, job
+    ) {
+        val response = saveAnaltrackingDatapointUseCaseAsync.execute(
+                SaveAnalyticsDatapointUseCaseInput(batteryChargePercentage, description)
+        )
+    }
+}

--- a/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
@@ -1,3 +1,5 @@
+@file:Suppress("UnusedImport")
+
 package com.ludoscity.herdr.data.transrecognition
 
 import android.app.*
@@ -38,7 +40,7 @@ class TransitionRecognitionService : Service(), KoinComponent {
         var isTrackingActivityTransition = false
         private const val CHANNEL_ID = "hdr_channel_00"
         private const val PACKAGE_NAME =
-                "com.ludoscity.herdr.data.transrecognition"
+            "com.ludoscity.herdr.data.transrecognition"
         private const val EXTRA_STARTED_FROM_NOTIFICATION = "$PACKAGE_NAME.started_from_notification"
         const val FOREGROUND_SERVICE_NOTIFICATION_ID = 696
 
@@ -93,24 +95,28 @@ class TransitionRecognitionService : Service(), KoinComponent {
         //intent.putExtra(EXTRA_STARTED_FROM_NOTIFICATION, true)
         //val servicePendingIntent = PendingIntent.getService(this, 0, intent,
         //        PendingIntent.FLAG_UPDATE_CURRENT)
-        val activityPendingIntent = PendingIntent.getActivity(this, 0,
-                Intent(this, HerdrActivity::class.java), 0)
+        val activityPendingIntent = PendingIntent.getActivity(
+            this, 0,
+            Intent(this, HerdrActivity::class.java), 0
+        )
 
         notifBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
-                .addAction(R.drawable.ic_launch_black_24dp, getString(R.string.open_app),
-                        activityPendingIntent)
-                //.addAction(R.drawable.ic_cancel_black_24dp, getString(R.string.cancel_tracing),
-                //        servicePendingIntent)
-                .setContentText(text)
-                .setContentTitle("Content Title")
-                .setOngoing(true)
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                //TODO: launcher icon
-                //.setSmallIcon(R.mipmap.ic_launcher)
-                .setSmallIcon(R.drawable.ic_cancel_black_24dp)
-                .setTicker(text)
-                .setOnlyAlertOnce(true)
-                .setWhen(System.currentTimeMillis())
+            .addAction(
+                R.drawable.ic_launch_black_24dp, getString(R.string.open_app),
+                activityPendingIntent
+            )
+            //.addAction(R.drawable.ic_cancel_black_24dp, getString(R.string.cancel_tracing),
+            //        servicePendingIntent)
+            .setContentText(text)
+            .setContentTitle("Content Title")
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            //TODO: launcher icon
+            //.setSmallIcon(R.mipmap.ic_launcher)
+            .setSmallIcon(R.drawable.ic_cancel_black_24dp)
+            .setTicker(text)
+            .setOnlyAlertOnce(true)
+            .setWhen(System.currentTimeMillis())
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             notifBuilder.setChannelId(CHANNEL_ID)
         }
@@ -142,20 +148,20 @@ class TransitionRecognitionService : Service(), KoinComponent {
                     // it shall also insert the geopoint if tracking is in progress (which it also maintains)
                     it.locations.getOrNull(0)?.let { userLocAsLocation ->
                         updateUserLocGeoTrackingDatapointUseCaseSync.execute(
-                                SaveGeoTrackingDatapointUseCaseInput(
-                                        GeoTrackingDatapoint(
-                                                -1,
-                                                -1,
-                                                userLocAsLocation.altitude,
-                                                userLocAsLocation.accuracy.toDouble(),
-                                                //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
-                                                0.0f.toDouble(),
-                                                userLocAsLocation.latitude,
-                                                userLocAsLocation.longitude,
-                                                0L,
-                                                ""
-                                        )
+                            SaveGeoTrackingDatapointUseCaseInput(
+                                GeoTrackingDatapoint(
+                                    -1,
+                                    -1,
+                                    userLocAsLocation.altitude,
+                                    userLocAsLocation.accuracy.toDouble(),
+                                    //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
+                                    0.0f.toDouble(),
+                                    userLocAsLocation.latitude,
+                                    userLocAsLocation.longitude,
+                                    0L,
+                                    ""
                                 )
+                            )
                         )
                     }
                 }
@@ -177,14 +183,16 @@ class TransitionRecognitionService : Service(), KoinComponent {
                 Log.d(TAG, "Requesting location updates for geolocation trac(k)ing")
                 //Utils.setRequestingLocationUpdates(this, true)
                 try {
-                    fusedLocationClient.requestLocationUpdates(locationRequest,
-                            locationCallback, Looper.myLooper())
+                    fusedLocationClient.requestLocationUpdates(
+                        locationRequest,
+                        locationCallback, Looper.myLooper()
+                    )
                     notifBuilder.setContentTitle("Tracing your movements")
                     notifManager.notify(FOREGROUND_SERVICE_NOTIFICATION_ID, notifBuilder.build())
 
                     saveAnalytics(
-                            null,
-                            "TransitionRecognitionService--requestLocationUpdates-success"
+                        null,
+                        "TransitionRecognitionService--requestLocationUpdates-success"
                     )
                 } catch (unlikely: SecurityException) {
                     Log.e(TAG, "Lost location permission. Could not request updates. $unlikely")
@@ -201,8 +209,8 @@ class TransitionRecognitionService : Service(), KoinComponent {
                     notifManager.notify(FOREGROUND_SERVICE_NOTIFICATION_ID, notifBuilder.build())
 
                     saveAnalytics(
-                            null,
-                            "TransitionRecognitionService--removeLocationUpdates-success"
+                        null,
+                        "TransitionRecognitionService--removeLocationUpdates-success"
                     )
                 } catch (unlikely: SecurityException) {
                     Log.e(TAG, "Lost location permission. Could not remove updates. $unlikely")
@@ -216,58 +224,60 @@ class TransitionRecognitionService : Service(), KoinComponent {
         val transitions = mutableListOf<ActivityTransition>()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.STILL)
-                        //.setActivityType(DetectedActivity.WALKING)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.STILL)
+                //.setActivityType(DetectedActivity.WALKING)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.STILL)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.STILL)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                .build()
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.WALKING)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.WALKING)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.WALKING)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.WALKING)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.RUNNING)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.RUNNING)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.RUNNING)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.RUNNING)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.ON_BICYCLE)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.ON_BICYCLE)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                .build()
 
         transitions +=
-                ActivityTransition.Builder()
-                        .setActivityType(DetectedActivity.ON_BICYCLE)
-                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
-                        .build()
+            ActivityTransition.Builder()
+                .setActivityType(DetectedActivity.ON_BICYCLE)
+                .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                .build()
 
         transitionRecognitionReq = ActivityTransitionRequest(transitions)
 
         val intent = applicationContext.intentFor<TransitionRecognitionIntentService>()
-        pendingIntent = PendingIntent.getService(applicationContext,
-                999, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+        pendingIntent = PendingIntent.getService(
+            applicationContext,
+            999, intent, PendingIntent.FLAG_UPDATE_CURRENT
+        )
 
         super.onCreate()
     }
@@ -282,30 +292,30 @@ class TransitionRecognitionService : Service(), KoinComponent {
     private fun getLastLocation() {
         try {
             fusedLocationClient.lastLocation
-                    .addOnCompleteListener { task ->
-                        if (task.isSuccessful && task.result != null) {
-                            task.result?.let {
-                                updateUserLocGeoTrackingDatapointUseCaseSync.execute(
-                                        SaveGeoTrackingDatapointUseCaseInput(
-                                                GeoTrackingDatapoint(
-                                                        -1,
-                                                        -1,
-                                                        it.altitude,
-                                                        it.accuracy.toDouble(),
-                                                        //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
-                                                        0.0f.toDouble(),
-                                                        it.latitude,
-                                                        it.longitude,
-                                                        0L,
-                                                        ""
-                                                )
-                                        )
+                .addOnCompleteListener { task ->
+                    if (task.isSuccessful && task.result != null) {
+                        task.result?.let {
+                            updateUserLocGeoTrackingDatapointUseCaseSync.execute(
+                                SaveGeoTrackingDatapointUseCaseInput(
+                                    GeoTrackingDatapoint(
+                                        -1,
+                                        -1,
+                                        it.altitude,
+                                        it.accuracy.toDouble(),
+                                        //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
+                                        0.0f.toDouble(),
+                                        it.latitude,
+                                        it.longitude,
+                                        0L,
+                                        ""
+                                    )
                                 )
-                            }
-                        } else {
-                            Log.w(TAG, "Failed to get location.")
+                            )
                         }
+                    } else {
+                        Log.w(TAG, "Failed to get location.")
                     }
+                }
         } catch (unlikely: SecurityException) {
             Log.e(TAG, "Lost location permission.$unlikely")
         }
@@ -315,11 +325,11 @@ class TransitionRecognitionService : Service(), KoinComponent {
     // https://github.com/f8full/findmybikes/blob/be3e9504d2441e0c0a661bee88bf6ca7276d2c14/app/src/main/java/com/ludoscity/findmybikes/data/database/tracking/AnalTrackingDatapoint.kt#L47
     private fun saveAnalytics(batteryChargePercentage: Long? = null,
                               description: String) = launchSilent(
-            coroutineContext,
-            exceptionHandler, job
+        coroutineContext,
+        exceptionHandler, job
     ) {
         val response = saveAnaltrackingDatapointUseCaseAsync.execute(
-                SaveAnalyticsDatapointUseCaseInput(batteryChargePercentage, description)
+            SaveAnalyticsDatapointUseCaseInput(batteryChargePercentage, description)
         )
     }
 
@@ -351,22 +361,22 @@ class TransitionRecognitionService : Service(), KoinComponent {
     private fun startTransitionUpdate() {
         // Start updates
         val task = ActivityRecognition
-                .getClient(this)
-                .requestActivityTransitionUpdates(transitionRecognitionReq, pendingIntent)
+            .getClient(this)
+            .requestActivityTransitionUpdates(transitionRecognitionReq, pendingIntent)
 
         task.addOnSuccessListener {
             isTrackingActivityTransition = true //TODO: whys insn't that in repo?
 
             saveAnalytics(
-                    null,
-                    "TransitionRecognitionService--startTransitionUpdate-success"
+                null,
+                "TransitionRecognitionService--startTransitionUpdate-success"
             )
         }
 
         task.addOnFailureListener { e ->
             saveAnalytics(
-                    null,
-                    "TransitionRecognitionService--startTransitionUpdate-failure"
+                null,
+                "TransitionRecognitionService--startTransitionUpdate-failure"
             )
             //stopSelf()
         }
@@ -376,23 +386,23 @@ class TransitionRecognitionService : Service(), KoinComponent {
         Log.e("prout", "Stopping updates")
         // Stop updates
         val task = ActivityRecognition
-                .getClient(this)
-                .removeActivityTransitionUpdates(pendingIntent)
+            .getClient(this)
+            .removeActivityTransitionUpdates(pendingIntent)
 
         task.addOnSuccessListener {
             pendingIntent.cancel()
             isTrackingActivityTransition = false
 
             saveAnalytics(
-                    null,
-                    "TransitionRecognitionService--removeActivityTransitionUpdates-success"
+                null,
+                "TransitionRecognitionService--removeActivityTransitionUpdates-success"
             )
         }
 
         task.addOnFailureListener { e ->
             saveAnalytics(
-                    null,
-                    "TransitionRecognitionService--removeActivityTransitionUpdates-failure"
+                null,
+                "TransitionRecognitionService--removeActivityTransitionUpdates-failure"
             )
         }
     }

--- a/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
@@ -21,6 +21,7 @@ import com.ludoscity.herdr.common.utils.launchSilent
 import com.ludoscity.herdr.ui.main.HerdrActivity
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
+import org.jetbrains.anko.intentFor
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import kotlin.coroutines.CoroutineContext

--- a/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
@@ -7,9 +7,8 @@ import android.os.*
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.google.android.gms.location.*
-import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
 import com.ludoscity.herdr.R
-
+import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseInput
 import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseInput
@@ -20,7 +19,6 @@ import com.ludoscity.herdr.common.utils.launchSilent
 import com.ludoscity.herdr.ui.main.HerdrActivity
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
-import org.jetbrains.anko.intentFor
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import kotlin.coroutines.CoroutineContext
@@ -176,7 +174,7 @@ class TransitionRecognitionService : Service(), KoinComponent {
 
         observeGeoTrackingUseCaseSync.execute(ObserveGeoTrackingUseCaseInput {
             if (it) {
-                Log.d(TAG, "Requesting location updates for tracing")
+                Log.d(TAG, "Requesting location updates for geolocation trac(k)ing")
                 //Utils.setRequestingLocationUpdates(this, true)
                 try {
                     fusedLocationClient.requestLocationUpdates(locationRequest,
@@ -192,7 +190,7 @@ class TransitionRecognitionService : Service(), KoinComponent {
                     Log.e(TAG, "Lost location permission. Could not request updates. $unlikely")
                 }
             } else {
-                Log.d(TAG, "Removing location updates for tracing")
+                Log.d(TAG, "Removing location updates for geolocation trac(k)ing")
                 try {
                     fusedLocationClient.removeLocationUpdates(locationCallback)
                     //This is saved in repo (sharedPref) in the sample

--- a/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/transrecognition/TransitionRecognitionService.kt
@@ -1,0 +1,401 @@
+package com.ludoscity.herdr.data.transrecognition
+
+import android.app.*
+import android.content.Context
+import android.content.Intent
+import android.os.*
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.google.android.gms.location.*
+import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
+import com.ludoscity.herdr.R
+
+import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
+import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseInput
+import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseInput
+import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseSync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeoTrackingDatapointUseCaseInput
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateUserLocGeoTrackingDatapointUseCaseSync
+import com.ludoscity.herdr.common.utils.launchSilent
+import com.ludoscity.herdr.ui.main.HerdrActivity
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.Job
+import org.jetbrains.anko.intentFor
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created by F8Full on 2019-07-02. This file is part of #findmybikes
+ * Modified by F8Full on 2020-08-02. This file is part of herdr
+ * A service class to monitor user activities transitions via activity transition recognition API
+ * https://developer.android.com/guide/topics/location/transitions
+ * As soon as it is started, it promotes itself to foreground. If repo indicates geotracking should happen
+ * it subrscribes to the fusedlocaitonclient for updates every second. Being a foreground service it can do that
+ */
+class TransitionRecognitionService : Service(), KoinComponent {
+
+    companion object {
+        private val TAG = TransitionRecognitionService::class.java.simpleName
+        var isTrackingActivityTransition = false
+        private const val CHANNEL_ID = "hdr_channel_00"
+        private const val PACKAGE_NAME =
+                "com.ludoscity.herdr.data.transrecognition"
+        private const val EXTRA_STARTED_FROM_NOTIFICATION = "$PACKAGE_NAME.started_from_notification"
+        const val FOREGROUND_SERVICE_NOTIFICATION_ID = 696
+
+        private var UPDATE_INTERVAL_IN_MILLISECONDS: Long = 2000
+        private var SHORTEST_UPDATE_INTERVAL_IN_MILLISECONDS: Long = 1000
+
+    }
+
+    // ASYNC - COROUTINES
+    private val coroutineContext: CoroutineContext by inject()
+    private var job: Job = Job()
+    private val exceptionHandler = CoroutineExceptionHandler { _, _ -> }
+
+    private val saveAnaltrackingDatapointUseCaseAsync:
+            SaveAnalyticsDatapointUseCaseAsync by inject()
+    private val updateUserLocGeoTrackingDatapointUseCaseSync:
+            UpdateUserLocGeoTrackingDatapointUseCaseSync by inject()
+    private val observeGeoTrackingUseCaseSync:
+            ObserveGeoTrackingUseCaseSync by inject()
+
+
+    //private lateinit var repo: FindMyBikesRepository
+    private lateinit var transitionRecognitionReq: ActivityTransitionRequest
+    private lateinit var pendingIntent: PendingIntent
+    private lateinit var fusedLocationClient: FusedLocationProviderClient
+    private lateinit var locationRequest: LocationRequest
+    private lateinit var locationCallback: LocationCallback
+    private lateinit var serviceHandler: Handler
+
+    private lateinit var notifBuilder: NotificationCompat.Builder
+    private lateinit var notifManager: NotificationManager
+
+    /**
+     * Returns the [NotificationCompat] used as part of the foreground service.
+     */
+    private// Extra to help us figure out if we arrived in onStartCommand via the notification or not.
+    // The PendingIntent that leads to a call to onStartCommand() in this service.
+    // The PendingIntent to launch activity.
+    // Set the Channel ID for Android O.
+    // Channel ID
+    val notification: Notification
+        get() {
+            return notifBuilder.build()
+        }
+
+    private fun initNotificationBuilder() {
+        //val intent = Intent(this, LocationTrackingService::class.java)
+
+        //TODO: user location retrieval in repo
+        //val text = repo.userLocation.value?.asLatLng()?.asString()
+        val text = "TODO: user loc in repo"
+        //intent.putExtra(EXTRA_STARTED_FROM_NOTIFICATION, true)
+        //val servicePendingIntent = PendingIntent.getService(this, 0, intent,
+        //        PendingIntent.FLAG_UPDATE_CURRENT)
+        val activityPendingIntent = PendingIntent.getActivity(this, 0,
+                Intent(this, HerdrActivity::class.java), 0)
+
+        notifBuilder = NotificationCompat.Builder(this, CHANNEL_ID)
+                .addAction(R.drawable.ic_launch_black_24dp, getString(R.string.open_app),
+                        activityPendingIntent)
+                //.addAction(R.drawable.ic_cancel_black_24dp, getString(R.string.cancel_tracing),
+                //        servicePendingIntent)
+                .setContentText(text)
+                .setContentTitle("Content Title")
+                .setOngoing(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                //TODO: launcher icon
+                //.setSmallIcon(R.mipmap.ic_launcher)
+                .setSmallIcon(R.drawable.ic_cancel_black_24dp)
+                .setTicker(text)
+                .setOnlyAlertOnce(true)
+                .setWhen(System.currentTimeMillis())
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notifBuilder.setChannelId(CHANNEL_ID)
+        }
+    }
+
+    private fun initNotificationManager() {
+        notifManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // Android O requires a Notification Channel.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = getString(R.string.app_name)
+            // Create the channel for the notification
+            val mChannel = NotificationChannel(CHANNEL_ID, name, NotificationManager.IMPORTANCE_DEFAULT)
+            // Set the Notification Channel for the Notification Manager.
+            notifManager.createNotificationChannel(mChannel)
+        }
+    }
+
+    override fun onCreate() {
+        //repo = InjectorUtils.provideRepository(application)
+
+        fusedLocationClient = LocationServices.getFusedLocationProviderClient(application)
+
+        locationCallback = object : LocationCallback() {
+            override fun onLocationResult(locationResult: LocationResult?) {
+
+                locationResult?.let {
+                    // repo should update it's userloc livedata (filtering should be aplied by observers?)
+                    // it shall also insert the geopoint if tracking is in progress (which it also maintains)
+                    it.locations.getOrNull(0)?.let { userLocAsLocation ->
+                        updateUserLocGeoTrackingDatapointUseCaseSync.execute(
+                                SaveGeoTrackingDatapointUseCaseInput(
+                                        GeoTrackingDatapoint(
+                                                -1,
+                                                -1,
+                                                userLocAsLocation.altitude,
+                                                userLocAsLocation.accuracy.toDouble(),
+                                                //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
+                                                0.0f.toDouble(),
+                                                userLocAsLocation.latitude,
+                                                userLocAsLocation.longitude,
+                                                0L,
+                                                ""
+                                        )
+                                )
+                        )
+                    }
+                }
+            }
+        }
+
+        createLocationRequest()
+        getLastLocation()
+
+        val handlerThread = HandlerThread(TAG)
+        handlerThread.start()
+        serviceHandler = Handler(handlerThread.looper)
+
+        initNotificationBuilder()
+        initNotificationManager()
+
+        observeGeoTrackingUseCaseSync.execute(ObserveGeoTrackingUseCaseInput {
+            if (it) {
+                Log.d(TAG, "Requesting location updates for tracing")
+                //Utils.setRequestingLocationUpdates(this, true)
+                try {
+                    fusedLocationClient.requestLocationUpdates(locationRequest,
+                            locationCallback, Looper.myLooper())
+                    notifBuilder.setContentTitle("Tracing your movements")
+                    notifManager.notify(FOREGROUND_SERVICE_NOTIFICATION_ID, notifBuilder.build())
+
+                    saveAnalytics(
+                            null,
+                            "TransitionRecognitionService--requestLocationUpdates-success"
+                    )
+                } catch (unlikely: SecurityException) {
+                    Log.e(TAG, "Lost location permission. Could not request updates. $unlikely")
+                }
+            } else {
+                Log.d(TAG, "Removing location updates for tracing")
+                try {
+                    fusedLocationClient.removeLocationUpdates(locationCallback)
+                    //This is saved in repo (sharedPref) in the sample
+                    //TODO: in our case : it meas the user wants to stop the tracing mode ??
+                    //Utils.setRequestingLocationUpdates(this, false)
+                    //stopSelf()
+                    notifBuilder.setContentTitle("Waiting for next movements")
+                    notifManager.notify(FOREGROUND_SERVICE_NOTIFICATION_ID, notifBuilder.build())
+
+                    saveAnalytics(
+                            null,
+                            "TransitionRecognitionService--removeLocationUpdates-success"
+                    )
+                } catch (unlikely: SecurityException) {
+                    Log.e(TAG, "Lost location permission. Could not remove updates. $unlikely")
+                }
+            }
+        })
+
+        //TODO: use case to get from repo? Yes, it's like getting user credentials?
+        //repo.isTrackingGeolocation.observeForever
+
+        val transitions = mutableListOf<ActivityTransition>()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.STILL)
+                        //.setActivityType(DetectedActivity.WALKING)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.STILL)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                        .build()
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.WALKING)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.WALKING)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.RUNNING)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.RUNNING)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.ON_BICYCLE)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_ENTER)
+                        .build()
+
+        transitions +=
+                ActivityTransition.Builder()
+                        .setActivityType(DetectedActivity.ON_BICYCLE)
+                        .setActivityTransition(ActivityTransition.ACTIVITY_TRANSITION_EXIT)
+                        .build()
+
+        transitionRecognitionReq = ActivityTransitionRequest(transitions)
+
+        val intent = applicationContext.intentFor<TransitionRecognitionIntentService>()
+        pendingIntent = PendingIntent.getService(applicationContext,
+                999, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+
+        super.onCreate()
+    }
+
+    private fun createLocationRequest() {
+        locationRequest = LocationRequest()
+        locationRequest.interval = UPDATE_INTERVAL_IN_MILLISECONDS
+        locationRequest.fastestInterval = SHORTEST_UPDATE_INTERVAL_IN_MILLISECONDS
+        locationRequest.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+    }
+
+    private fun getLastLocation() {
+        try {
+            fusedLocationClient.lastLocation
+                    .addOnCompleteListener { task ->
+                        if (task.isSuccessful && task.result != null) {
+                            task.result?.let {
+                                updateUserLocGeoTrackingDatapointUseCaseSync.execute(
+                                        SaveGeoTrackingDatapointUseCaseInput(
+                                                GeoTrackingDatapoint(
+                                                        -1,
+                                                        -1,
+                                                        it.altitude,
+                                                        it.accuracy.toDouble(),
+                                                        //userLocAsLocation.verticalAccuracyMeters, //TODO: requires API LEVEL 26
+                                                        0.0f.toDouble(),
+                                                        it.latitude,
+                                                        it.longitude,
+                                                        0L,
+                                                        ""
+                                                )
+                                        )
+                                )
+                            }
+                        } else {
+                            Log.w(TAG, "Failed to get location.")
+                        }
+                    }
+        } catch (unlikely: SecurityException) {
+            Log.e(TAG, "Lost location permission.$unlikely")
+        }
+    }
+
+    //FIXME: actual value always being null see
+    // https://github.com/f8full/findmybikes/blob/be3e9504d2441e0c0a661bee88bf6ca7276d2c14/app/src/main/java/com/ludoscity/findmybikes/data/database/tracking/AnalTrackingDatapoint.kt#L47
+    private fun saveAnalytics(batteryChargePercentage: Long? = null,
+                              description: String) = launchSilent(
+            coroutineContext,
+            exceptionHandler, job
+    ) {
+        val response = saveAnaltrackingDatapointUseCaseAsync.execute(
+                SaveAnalyticsDatapointUseCaseInput(batteryChargePercentage, description)
+        )
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+
+        goForeground()
+
+        startTransitionUpdate()
+
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+
+        stopTransitionUpdates()
+
+        super.onDestroy()
+    }
+
+    private fun goForeground() {
+        startForeground(FOREGROUND_SERVICE_NOTIFICATION_ID, notification)
+    }
+
+    private fun startTransitionUpdate() {
+        // Start updates
+        val task = ActivityRecognition
+                .getClient(this)
+                .requestActivityTransitionUpdates(transitionRecognitionReq, pendingIntent)
+
+        task.addOnSuccessListener {
+            isTrackingActivityTransition = true //TODO: whys insn't that in repo?
+
+            saveAnalytics(
+                    null,
+                    "TransitionRecognitionService--startTransitionUpdate-success"
+            )
+        }
+
+        task.addOnFailureListener { e ->
+            saveAnalytics(
+                    null,
+                    "TransitionRecognitionService--startTransitionUpdate-failure"
+            )
+            //stopSelf()
+        }
+    }
+
+    private fun stopTransitionUpdates() {
+        Log.e("prout", "Stopping updates")
+        // Stop updates
+        val task = ActivityRecognition
+                .getClient(this)
+                .removeActivityTransitionUpdates(pendingIntent)
+
+        task.addOnSuccessListener {
+            pendingIntent.cancel()
+            isTrackingActivityTransition = false
+
+            saveAnalytics(
+                    null,
+                    "TransitionRecognitionService--removeActivityTransitionUpdates-success"
+            )
+        }
+
+        task.addOnFailureListener { e ->
+            saveAnalytics(
+                    null,
+                    "TransitionRecognitionService--removeActivityTransitionUpdates-failure"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -19,14 +19,36 @@
 package com.ludoscity.herdr.ui.main
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
 import com.ludoscity.herdr.R
+import com.ludoscity.herdr.common.ui.drivelogin.SuccessUserCredentials
+import com.ludoscity.herdr.common.ui.main.HerdrViewModel
+import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
+import com.ludoscity.herdr.databinding.ActivityHerdrBinding
+import com.ludoscity.herdr.utils.startServiceForeground
+import dev.icerock.moko.mvvm.MvvmActivity
+import dev.icerock.moko.mvvm.createViewModelFactory
+import org.jetbrains.anko.intentFor
 
-class HerdrActivity : AppCompatActivity() {
+class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
+
+    override val layoutId: Int = R.layout.activity_herdr
+    override val viewModelVariableId: Int = com.ludoscity.herdr.BR.herdrViewModel
+    override val viewModelClass: Class<HerdrViewModel> = HerdrViewModel::class.java
+
+    override fun viewModelFactory(): ViewModelProvider.Factory {
+        return createViewModelFactory { HerdrViewModel() }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setContentView(R.layout.activity_herdr)
+        viewModel.isLoggedIn.addObserver {
+            if (it) {
+                startServiceForeground(intentFor<TransitionRecognitionService>())
+            } else {
+                stopService(intentFor<TransitionRecognitionService>())
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -18,8 +18,13 @@
 
 package com.ludoscity.herdr.ui.main
 
+import android.Manifest
+import android.content.pm.PackageManager
 import android.os.Bundle
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
+import com.fondesa.kpermissions.extension.listeners
+import com.fondesa.kpermissions.extension.permissionsBuilder
 import com.ludoscity.herdr.R
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
 import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
@@ -55,5 +60,33 @@ class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
                 }
             }
         }
+
+        viewModel.setLocationPermissionGranted(
+            ContextCompat.checkSelfPermission(
+                application,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    override fun onResume() {
+        if (!viewModel.hasLocationPermission().value) {
+            val request = permissionsBuilder(android.Manifest.permission.ACCESS_FINE_LOCATION).build()
+
+            //log.i(TAG, "Sending location permission request")
+            request.send()
+
+            request.listeners {
+                onAccepted { viewModel.setLocationPermissionGranted(true) }
+                onDenied { viewModel.setLocationPermissionGranted(false) }
+                onPermanentlyDenied { viewModel.setLocationPermissionGranted(false) }
+                //onShouldShowRationale { perms, nonce ->
+                //}
+            }
+        } /*else {
+            Log.i(TAG, "Activity was resumed and already have location permission, carrying on...")
+        }*/
+
+        super.onResume()
     }
 }

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -24,8 +24,10 @@ import com.ludoscity.herdr.R
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
 import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
 import com.ludoscity.herdr.databinding.ActivityHerdrBinding
+import com.ludoscity.herdr.utils.startServiceForeground
 import dev.icerock.moko.mvvm.MvvmActivity
 import dev.icerock.moko.mvvm.createViewModelFactory
+import org.jetbrains.anko.intentFor
 
 class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
 

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -21,14 +21,11 @@ package com.ludoscity.herdr.ui.main
 import android.os.Bundle
 import androidx.lifecycle.ViewModelProvider
 import com.ludoscity.herdr.R
-import com.ludoscity.herdr.common.ui.drivelogin.SuccessUserCredentials
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
 import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
 import com.ludoscity.herdr.databinding.ActivityHerdrBinding
-import com.ludoscity.herdr.utils.startServiceForeground
 import dev.icerock.moko.mvvm.MvvmActivity
 import dev.icerock.moko.mvvm.createViewModelFactory
-import org.jetbrains.anko.intentFor
 
 class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
 
@@ -43,11 +40,17 @@ class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        viewModel.isLoggedIn.addObserver {
-            if (it) {
-                startServiceForeground(intentFor<TransitionRecognitionService>())
-            } else {
-                stopService(intentFor<TransitionRecognitionService>())
+        //TODO: loggedIn signal is only really useful for data upload
+        // app already can trac(k)e user activity changes (bike <--> walk <--> ...) and trac(k)e geolocation (GPS)
+        // and persist in local db.
+        // For now, logging out disconnects both tracking, nothing gets persisted to db
+        viewModel.addLoggedInObserver {
+            it?.let { loggedIn ->
+                if (loggedIn) {
+                    startServiceForeground(intentFor<TransitionRecognitionService>())
+                } else {
+                    stopService(intentFor<TransitionRecognitionService>())
+                }
             }
         }
     }

--- a/app/src/main/java/com/ludoscity/herdr/utils/Utils.kt
+++ b/app/src/main/java/com/ludoscity/herdr/utils/Utils.kt
@@ -18,9 +18,35 @@
 
 package com.ludoscity.herdr.utils
 
+import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.text.Editable
 import android.text.TextWatcher
 import android.widget.EditText
+
+object Utils {
+    fun getSimpleDateFormatPattern(): String {
+        //see: https://developer.android.com/reference/java/text/SimpleDateFormat
+        //https://stackoverflow.com/questions/28373610/android-parse-string-to-date-unknown-pattern-character-x
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+        else
+            "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+    }
+}
+/**
+ * Extension function to start foreground services
+ *
+ * @param service   the intent of service to be started
+ */
+fun Context.startServiceForeground(service: Intent) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        startForegroundService(service)
+    } else {
+        startService(service)
+    }
+}
 
 /**
  * Extension function to simplify setting an afterTextChanged action to EditText components.

--- a/app/src/main/res/drawable/ic_cancel_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_cancel_black_24dp.xml
@@ -16,8 +16,12 @@
   ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<resources>
-    <string name="app_name">herdr</string>
-    <string name="create_account"><u>Create New Account</u></string>
-    <string name="open_app">open app</string>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_launch_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_launch_black_24dp.xml
@@ -16,8 +16,12 @@
   ~     along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<resources>
-    <string name="app_name">herdr</string>
-    <string name="create_account"><u>Create New Account</u></string>
-    <string name="open_app">open app</string>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,19H5V5h7V3H5c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2v-7h-2v7zM14,3v2h3.59l-9.83,9.83 1.41,1.41L19,6.41V10h2V3h-7z"/>
+</vector>

--- a/app/src/main/res/layout/activity_herdr.xml
+++ b/app/src/main/res/layout/activity_herdr.xml
@@ -21,9 +21,17 @@
      including layouts, and it's a good idea to use it.
      See: https://developer.android.com/training/improving-layouts/reusing-layouts -->
 
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="herdrViewModel"
+            type="com.ludoscity.herdr.common.ui.main.HerdrViewModel" />
+    </data>
+
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
@@ -34,4 +42,4 @@
         app:navGraph="@navigation/navigation"
         tools:context=".HerdrActivity"/>
 
-</merge>
+</layout>

--- a/build.gradle
+++ b/build.gradle
@@ -22,21 +22,25 @@ buildscript {
         jcenter()
     }
     ext {
+        ankoVersion = "0.10.3"
         androidxLifecycleVersion = "2.2.0"
         appCompatVersion = "1.1.0"
         appAuthVersion = "0.7.1"
         constraintLayoutVersion = "1.1.3"
         coroutineVersion = "1.3.5"
+        deviceNamesVersion = "1.1.7"
         fragmentVersion = "1.2.4"
         gradleVersion = "3.6.2"
         kermitVersion = "0.1.7"
         koinVersion = "3.0.0-alpha-2"
         kotlinVersion = "1.3.72"
+        //kpermissionsVersion = "1.0.0"
         ktorVersion = "1.3.2"
         materialDesignVersion = "1.1.0"
         mokoMvvmVersion = "0.6.0"
         navigationVersion = "2.2.2"
-        securityCryptoVersion = "1.0.0-rc01"
+        playServicesVersion = "17.0.0"
+        securityCryptoVersion = "1.0.0-rc02"
         serializerVersion = "0.20.0"
         sqlDelightVersion = "1.4.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         kermitVersion = "0.1.7"
         koinVersion = "3.0.0-alpha-2"
         kotlinVersion = "1.3.72"
-        //kpermissionsVersion = "1.0.0"
+        kpermissionsVersion = "1.0.0"
         ktorVersion = "1.3.2"
         materialDesignVersion = "1.1.0"
         mokoMvvmVersion = "0.6.0"


### PR DESCRIPTION
## Description

closes #13
Tracking - Write to database

PR contains code taken from [#findmybikes](https://github.com/f8full/findmybikes) and adapted to use activity transition recognition API as well as switching on geotracking when some transition happens.
In other terms, it start the GPS when user enter certain activities (walking, biking, driving, ...) and fills the local db with GPS fixes. It can also stop the tracking when the activity is over.

In this version, user activity tracking starts when they log in and stops when they log out.

## TODO

- [x] fix #13  having to restart app when logging in/out to start/stop foreground service (permanent notification)
- [x] location permission asking