### PR TITLE
Cloud folder setup for raw data output

### DIFF
--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/INetworkDataPipe.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/INetworkDataPipe.kt
@@ -20,6 +20,7 @@ package com.ludoscity.herdr.common.data.network
 
 import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.domain.entity.AuthClientRegistration
+import com.ludoscity.herdr.common.domain.entity.RawDataCloudFolderConfiguration
 import com.ludoscity.herdr.common.domain.entity.UserCredentials
 
 interface INetworkDataPipe {
@@ -36,5 +37,11 @@ interface INetworkDataPipe {
 
     suspend fun unregisterAuthClient(authRegistrationInfo: AuthClientRegistration): Response<Unit>
 
-    suspend fun postDirectory(stackBase: String, dirName: String): Response<String>
+    suspend fun postDirectory(stackBase: String, dirName: String, tagList: List<String>):
+            Response<RawDataCloudFolderConfiguration>
+
+    suspend fun getFileMetadata(
+        stackBase: String,
+        fullPathWithSlashes: String
+    ): Response<RawDataCloudFolderConfiguration>
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/FileRelatedRequestReply.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/FileRelatedRequestReply.kt
@@ -1,0 +1,30 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.data.network.cozy
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CozyFileDescAttributes(val name: String, val path: String)
+
+@Serializable
+data class CozyFileDesc(val id: String, val attributes: CozyFileDescAttributes)
+
+@Serializable
+data class CozyFileDescAnswerRoot(val data: CozyFileDesc)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -43,7 +43,7 @@ private val coreModule = module {
     single { UnregisterAuthClientUseCaseAsync() }
     single { RetrieveAccessAndRefreshTokenUseCaseAsync() }
     single { RefreshAccessAndRefreshTokenUseCaseAsync() }
-    single { CreateDirectoryUseCaseAsync() }
+    single { SetupDirectoryUseCaseAsync() }
     single { SaveGeoTrackingDatapointUseCaseAsync() }
     single { SaveAnalyticsDatapointUseCaseAsync() }
     single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/entity/RawDataCloudFolderConfiguration.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/entity/RawDataCloudFolderConfiguration.kt
@@ -1,0 +1,16 @@
+package com.ludoscity.herdr.common.domain.entity
+
+/**
+ * Created by F8Full on 2019-06-17. This file is part of #findmybikes
+ *
+ */
+/**
+ * Data class that captures user information for logged in users retrieved from Repository
+ * // If user credentials will be cached in local storage, it is recommended it be encrypted
+// @see https://developer.android.com/training/articles/keystore
+ */
+data class RawDataCloudFolderConfiguration(
+        val id: String,
+        val name: String,
+        val path: String
+)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/SetupDirectoryUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/SetupDirectoryUseCaseAsync.kt
@@ -19,14 +19,15 @@ package com.ludoscity.herdr.common.domain.usecase.login
 
 import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.data.repository.LoginRepository
+import com.ludoscity.herdr.common.domain.entity.RawDataCloudFolderConfiguration
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-class CreateDirectoryUseCaseAsync : KoinComponent,
-    BaseUseCaseAsync<Nothing, String>() {
+class SetupDirectoryUseCaseAsync : KoinComponent,
+    BaseUseCaseAsync<SetupDirectoryUseCaseInput, RawDataCloudFolderConfiguration>() {
     private val repo: LoginRepository by inject()
-    override suspend fun run(): Response<String> {
-        return repo.createDirectory()
+    override suspend fun run(): Response<RawDataCloudFolderConfiguration> {
+        return repo.setupDirectory(input!!.name, input!!.tags)
     }
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/SetupDirectoryUseCaseInput.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/login/SetupDirectoryUseCaseInput.kt
@@ -1,0 +1,28 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.domain.usecase.login
+
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseInput
+
+class SetupDirectoryUseCaseInput(val name: String, val tags: List<String>) :
+    BaseUseCaseInput {
+    override fun validate(): Boolean {
+        return name.isNotEmpty() && name.isNotBlank()
+    }
+}


### PR DESCRIPTION
#### Description

This PR contains changes so that the common part of the code can setup the connection with the data directory on the remote cloud service. In the case of Cozy which is the only supported one so far, it consist in retrieving the following pieces of data
- `id` --> used to compose future data upload requests
- `name` --> for future UI/UX use
- `path` --> for future UI/UX use 

from either (if folder doesn't already exist) https://github.com/cozy/cozy-stack/blob/master/docs/files.md#post-filesdir-id
or (if a folder at the same path already exists) https://github.com/cozy/cozy-stack/blob/master/docs/files.md#get-filesmetadata

It additionally exposes the retrieved data as a `LiveData` object