### PR TITLE
Data upload workers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -132,6 +132,7 @@ kotlin {
                 implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
                 implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
                 implementation "com.google.android.gms:play-services-location:$playServicesVersion"
+                implementation "androidx.work:work-runtime-ktx:$workVersion"
                 // Kotlin Anko
                 implementation "org.jetbrains.anko:anko-commons:$ankoVersion"
 

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/database/dao/AnalTrackingDatapointDao.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/database/dao/AnalTrackingDatapointDao.kt
@@ -20,5 +20,8 @@ class AnalTrackingDatapointDao(database: HerdrDatabase) {
         db.deleteById(analTrackingDatapoint.id)
     }
 
+    //TODO: check latest versions of KamMPKit to use Coroutine flow
+    internal fun selectReadyForUploadAll(): List<AnalTrackingDatapoint> = db.selectReadyForUploadAll().executeAsList()
+
     internal fun select(): List<AnalTrackingDatapoint> = db.selectAll().executeAsList()
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/database/dao/GeoTrackingDatapointDao.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/database/dao/GeoTrackingDatapointDao.kt
@@ -20,5 +20,8 @@ class GeoTrackingDatapointDao(database: HerdrDatabase) {
         db.deleteById(geoTrackingDatapoint.id)
     }
 
+    //TODO: check latest versions of KamMPKit to use Coroutine flow
+    internal fun selectReadyForUploadAll(): List<GeoTrackingDatapoint> = db.selectReadyForUploadAll().executeAsList()
+
     internal fun select(): List<GeoTrackingDatapoint> = db.selectAll().executeAsList()
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/INetworkDataPipe.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/INetworkDataPipe.kt
@@ -44,4 +44,13 @@ interface INetworkDataPipe {
         stackBase: String,
         fullPathWithSlashes: String
     ): Response<RawDataCloudFolderConfiguration>
+
+    suspend fun postFile(
+        stackBase: String,
+        directoryId: String,
+        filename: String,
+        tagList: List<String>,
+        contentJsonString: String,
+        createdAt: String
+    ): Response<Unit>
 }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/AnalTrackingUploadRequestBody.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/AnalTrackingUploadRequestBody.kt
@@ -16,17 +16,19 @@
  *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package com.ludoscity.herdr.common
+package com.ludoscity.herdr.common.data.network.cozy
 
-expect object Platform {
-    val now: Long
-    val nowString: String
+import kotlinx.serialization.Serializable
 
-    fun toISO8601UTC(timestampString: String): String
-    fun hashBase64MD5(toHash: ByteArray): String
-    val app_version: String
-    val api_level: Long
-    val device_model: String
-    val language: String
-    val country: String
-}
+@Serializable
+data class AnalTrackingUploadRequestBody(
+    val timestampEpoch: Long,
+    val appVersion: String,
+    val apiLevel: Long,
+    val deviceModel: String,
+    val language: String,
+    val country: String,
+    val batteryChargePercentage: Long?,
+    val description: String,
+    val timestamp: String
+)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/GeoTrackingUploadRequestBody.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/network/cozy/GeoTrackingUploadRequestBody.kt
@@ -1,0 +1,32 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.data.network.cozy
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GeoTrackingUploadRequestBody(
+    val timestampEpoch: Long,
+    val altitude: Double?,
+    val accuracyHorizontalMeters: Double,
+    val accuracyVerticalMeters: Double?,
+    val latitude: Double,
+    val longitude: Double,
+    val timestamp: String
+)

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
@@ -21,10 +21,16 @@ package com.ludoscity.herdr.common.data.repository
 import co.touchlab.kermit.Kermit
 import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
+import com.ludoscity.herdr.common.data.SecureDataStore
 import com.ludoscity.herdr.common.data.database.HerdrDatabase
 import com.ludoscity.herdr.common.data.database.dao.AnalTrackingDatapointDao
+import com.ludoscity.herdr.common.data.network.INetworkDataPipe
+import com.ludoscity.herdr.common.data.network.cozy.AnalTrackingUploadRequestBody
 import dev.icerock.moko.mvvm.livedata.LiveData
 import dev.icerock.moko.mvvm.livedata.MutableLiveData
+import io.ktor.utils.io.errors.IOException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.koin.core.parameter.parametersOf
@@ -38,6 +44,8 @@ class AnalTrackingRepository : KoinComponent {
     private val log: Kermit by inject { parametersOf("AnalTrackingRepository") }
 
     private val herdrDb: HerdrDatabase by inject()
+    private val networkDataPipe: INetworkDataPipe by inject()
+    private val secureDataStore: SecureDataStore by inject()
 
     private val _hasLocationPermission = MutableLiveData(false)
     val hasLocationPermission: LiveData<Boolean> = _hasLocationPermission
@@ -66,32 +74,63 @@ class AnalTrackingRepository : KoinComponent {
     suspend fun uploadAllAnalTrackingDatapointReadyForUpload(): Response<Unit> {
 
         val analTrackingDao = AnalTrackingDatapointDao(herdrDb)
+        var atLeastOneError = true
         analTrackingDao.selectReadyForUploadAll().forEach {
-            //networkDataPipe.uploadFile
-            //if network reply is success
-            //analTrackingDao.updateUploadCompleted(it.id)
-            //else we could maybe gather the list of everyone concerned by failure
+            secureDataStore.retrieveString(
+                LoginRepository.authClientRegistrationBaseUrlStoreKey
+            )?.let { stackBase ->
+                log.d { "We have a stack address" }
+                secureDataStore.retrieveString(
+                    LoginRepository.cloudDirectoryId
+                )?.let { cloudDirectoryId ->
+                    log.d { "We have a directory id" }
+                    val networkReply = networkDataPipe.postFile(
+                        stackBase,
+                        cloudDirectoryId,
+                        "${it.timestamp}_ANALYTICS.json",
+                        listOf("herdr", "analytics"),
+                        Json(JsonConfiguration.Stable).stringify(
+                            AnalTrackingUploadRequestBody.serializer(),
+                            AnalTrackingUploadRequestBody(
+                                it.timestamp_epoch,
+                                it.app_version,
+                                it.api_level,
+                                it.device_model,
+                                it.language,
+                                it.country,
+                                it.battery_charge_percentage,
+                                it.description,
+                                it.timestamp
+                            )
+                        ),
+                        it.timestamp
+                    )
+
+                    when (networkReply) {
+                        is Response.Success -> {
+                            log.d { "Upload success, flagged record of name: ${it.timestamp}_ANALYTICS.json for deletion" }
+                            analTrackingDao.updateUploadCompleted(it.id)
+                            atLeastOneError = false
+                        }
+                        is Response.Error -> {
+                            if (networkReply.code == 409) {
+                                log.i { "Recovered from 409, flagged record: ${it.timestamp}_ANALYTICS.json for deletion" }
+                                analTrackingDao.updateUploadCompleted(it.id)
+                                atLeastOneError = false
+                            } /*else { //default is true
+                                atLeastOneError = true
+                            }*/
+                        }
+                    }
+                }
+            }
         }
 
-        return Response.Success(Unit)
-
-
-        /*getAuthClientRegistration("", true)
-        getUserCredentials("", true)
-
-        val result = networkDataPipe.refreshAccessToken(authClientRegistration!!, userCredentials!!)
-
-        return if (result is Response.Success) {
-            //log.d { "Updating credentials in repository with access token: ${result.data.accessToken}" }
-            userCredentials = result.data
-            secureDataStore.apply {
-                storeString(userCredentialAccessTokenStoreKey, userCredentials!!.accessToken)
-                storeString(userCredentialRefreshTokenStoreKey, userCredentials!!.refreshToken)
-            }
-            result
+        return if (atLeastOneError) {
+            Response.Error(IOException("Some error happened during the upload process"))
         } else {
-            Response.Error(IOException("Could not refresh token"))
-        }*/
+            Response.Success(Unit)
+        }
     }
 
 //    @Update

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
@@ -55,6 +55,37 @@ class AnalTrackingRepository : KoinComponent {
         return Response.Success(analTrackingDao.select())
     }
 
+    suspend fun uploadAllAnalTrackingDatapointReadyForUpload(): Response<Unit> {
+
+        val analTrackingDao = AnalTrackingDatapointDao(herdrDb)
+        analTrackingDao.selectReadyForUploadAll().forEach {
+            //networkDataPipe.uploadFile
+            //if network reply is success
+            analTrackingDao.updateUploadCompleted(it.id)
+            //else we could maybe gather the list of everyone concerned by failure
+        }
+
+        return Response.Success(Unit)
+
+
+        /*getAuthClientRegistration("", true)
+        getUserCredentials("", true)
+
+        val result = networkDataPipe.refreshAccessToken(authClientRegistration!!, userCredentials!!)
+
+        return if (result is Response.Success) {
+            //log.d { "Updating credentials in repository with access token: ${result.data.accessToken}" }
+            userCredentials = result.data
+            secureDataStore.apply {
+                storeString(userCredentialAccessTokenStoreKey, userCredentials!!.accessToken)
+                storeString(userCredentialRefreshTokenStoreKey, userCredentials!!.refreshToken)
+            }
+            result
+        } else {
+            Response.Error(IOException("Could not refresh token"))
+        }*/
+    }
+
 //    @Update
 //    fun update(record: AnalTrackingDatapoint)
 //

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/AnalTrackingRepository.kt
@@ -18,6 +18,7 @@
 
 package com.ludoscity.herdr.common.data.repository
 
+import co.touchlab.kermit.Kermit
 import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
 import com.ludoscity.herdr.common.data.database.HerdrDatabase
@@ -26,8 +27,15 @@ import dev.icerock.moko.mvvm.livedata.LiveData
 import dev.icerock.moko.mvvm.livedata.MutableLiveData
 import org.koin.core.KoinComponent
 import org.koin.core.inject
+import org.koin.core.parameter.parametersOf
 
 class AnalTrackingRepository : KoinComponent {
+
+    companion object {
+        const val UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME = "herdr-upload-anal-worker"
+    }
+
+    private val log: Kermit by inject { parametersOf("AnalTrackingRepository") }
 
     private val herdrDb: HerdrDatabase by inject()
 
@@ -61,7 +69,7 @@ class AnalTrackingRepository : KoinComponent {
         analTrackingDao.selectReadyForUploadAll().forEach {
             //networkDataPipe.uploadFile
             //if network reply is success
-            analTrackingDao.updateUploadCompleted(it.id)
+            //analTrackingDao.updateUploadCompleted(it.id)
             //else we could maybe gather the list of everyone concerned by failure
         }
 

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/GeoTrackingRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/GeoTrackingRepository.kt
@@ -18,17 +18,33 @@
 
 package com.ludoscity.herdr.common.data.repository
 
+import co.touchlab.kermit.Kermit
 import com.ludoscity.herdr.common.base.Response
 import com.ludoscity.herdr.common.data.GeoTrackingDatapoint
+import com.ludoscity.herdr.common.data.SecureDataStore
 import com.ludoscity.herdr.common.data.database.HerdrDatabase
 import com.ludoscity.herdr.common.data.database.dao.GeoTrackingDatapointDao
+import com.ludoscity.herdr.common.data.network.INetworkDataPipe
+import com.ludoscity.herdr.common.data.network.cozy.GeoTrackingUploadRequestBody
 import dev.icerock.moko.mvvm.livedata.MutableLiveData
+import io.ktor.utils.io.errors.IOException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.koin.core.KoinComponent
 import org.koin.core.inject
+import org.koin.core.parameter.parametersOf
 
 class GeoTrackingRepository : KoinComponent {
 
+    companion object {
+        const val UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME = "herdr-upload-geo-worker"
+    }
+
+    private val log: Kermit by inject { parametersOf("GeoTrackingRepository") }
+
     private val herdrDb: HerdrDatabase by inject()
+    private val networkDataPipe: INetworkDataPipe by inject()
+    private val secureDataStore: SecureDataStore by inject()
 
 
     private val _userLoc = MutableLiveData<GeoTrackingDatapoint?>(null)
@@ -66,6 +82,65 @@ class GeoTrackingRepository : KoinComponent {
         //TODO: retrieve timestamp epoch here for both platforms at once
         geoTrackingDao.insert(record)
         return Response.Success(geoTrackingDao.select())
+    }
+
+    suspend fun uploadAllGeoTrackingDatapointReadyForUpload(): Response<Unit> {
+        val geoTrackingDao = GeoTrackingDatapointDao(herdrDb)
+        var atLeastOneError = true
+        geoTrackingDao.selectReadyForUploadAll().forEach {
+            secureDataStore.retrieveString(
+                LoginRepository.authClientRegistrationBaseUrlStoreKey
+            )?.let { stackBase ->
+                log.d { "We have a stack address" }
+                secureDataStore.retrieveString(
+                    LoginRepository.cloudDirectoryId
+                )?.let { cloudDirectoryId ->
+                    log.d { "We have a directory id" }
+                    val networkReply = networkDataPipe.postFile(
+                        stackBase,
+                        cloudDirectoryId,
+                        "${it.timestamp}_GEOLOCATION.json",
+                        listOf("herdr", "geolocation"),
+                        Json(JsonConfiguration.Stable).stringify(
+                            GeoTrackingUploadRequestBody.serializer(),
+                            GeoTrackingUploadRequestBody(
+                                it.timestamp_epoch,
+                                it.altitude,
+                                it.accuracy_horizontal_meters,
+                                it.accuracy_vertical_meters,
+                                it.latitude,
+                                it.longitude,
+                                it.timestamp
+                            )
+                        ),
+                        it.timestamp
+                    )
+
+                    when (networkReply) {
+                        is Response.Success -> {
+                            log.d { "Upload success, flagged record of name: ${it.timestamp}_GEOLOCATION.json for deletion" }
+                            geoTrackingDao.updateUploadCompleted(it.id)
+                            atLeastOneError = false
+                        }
+                        is Response.Error -> {
+                            if (networkReply.code == 409) {
+                                log.i { "Recovered from 409, flagged record: ${it.timestamp}_GEOLOCATION.json for deletion" }
+                                geoTrackingDao.updateUploadCompleted(it.id)
+                                atLeastOneError = false
+                            } /*else { //default is true
+                                atLeastOneError = true
+                            }*/
+                        }
+                    }
+                }
+            }
+        }
+
+        return if (atLeastOneError) {
+            Response.Error(IOException("Some error happened during the upload process"))
+        } else {
+            Response.Success(Unit)
+        }
     }
 
 //    @Update

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -11,10 +11,7 @@ import com.ludoscity.herdr.common.domain.usecase.analytics.GetPermissionGrantedU
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.analytics.UpdatePermissionGrantedUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.analytics.UploadAllAnalyticsDatapointUseCaseAsync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseSync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeoTrackingDatapointUseCaseAsync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseSync
-import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateUserLocGeoTrackingDatapointUseCaseSync
+import com.ludoscity.herdr.common.domain.usecase.geotracking.*
 import com.ludoscity.herdr.common.domain.usecase.login.*
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
@@ -48,6 +45,7 @@ private val coreModule = module {
     single { SaveGeoTrackingDatapointUseCaseAsync() }
     single { SaveAnalyticsDatapointUseCaseAsync() }
     single { UploadAllAnalyticsDatapointUseCaseAsync() }
+    single { UploadAllGeoTrackingDatapointUseCaseAsync() }
     single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }
     single { ObserveGeoTrackingUseCaseSync() }
     single { ObserveLoggedInUseCaseSync() }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -10,6 +10,7 @@ import com.ludoscity.herdr.common.data.repository.LoginRepository
 import com.ludoscity.herdr.common.domain.usecase.analytics.GetPermissionGrantedUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.analytics.SaveAnalyticsDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.analytics.UpdatePermissionGrantedUseCaseSync
+import com.ludoscity.herdr.common.domain.usecase.analytics.UploadAllAnalyticsDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.ObserveGeoTrackingUseCaseSync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.SaveGeoTrackingDatapointUseCaseAsync
 import com.ludoscity.herdr.common.domain.usecase.geotracking.UpdateGeoTrackingUseCaseSync
@@ -46,6 +47,7 @@ private val coreModule = module {
     single { SetupDirectoryUseCaseAsync() }
     single { SaveGeoTrackingDatapointUseCaseAsync() }
     single { SaveAnalyticsDatapointUseCaseAsync() }
+    single { UploadAllAnalyticsDatapointUseCaseAsync() }
     single { UpdateUserLocGeoTrackingDatapointUseCaseSync() }
     single { ObserveGeoTrackingUseCaseSync() }
     single { ObserveLoggedInUseCaseSync() }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAllAnalyticsDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAllAnalyticsDatapointUseCaseAsync.kt
@@ -24,7 +24,7 @@ import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
-class UploadAnalyticsDatapointUseCaseAsync : KoinComponent,
+class UploadAllAnalyticsDatapointUseCaseAsync : KoinComponent,
     BaseUseCaseAsync<Nothing, Unit>() {
     private val repo: AnalTrackingRepository by inject()
     override suspend fun run(): Response<Unit> {

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAnalyticsDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAnalyticsDatapointUseCaseAsync.kt
@@ -1,0 +1,33 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.ludoscity.herdr.common.domain.usecase.analytics
+
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
+import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class UploadAnalyticsDatapointUseCaseAsync : KoinComponent,
+    BaseUseCaseAsync<Nothing, Unit>() {
+    private val repo: AnalTrackingRepository by inject()
+    override suspend fun run(): Response<Unit> {
+        return repo.uploadAllAnalTrackingDatapointReadyForUpload()
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UploadAllGeoTrackingDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UploadAllGeoTrackingDatapointUseCaseAsync.kt
@@ -1,0 +1,32 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.ludoscity.herdr.common.domain.usecase.geotracking
+
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+class UploadAllGeoTrackingDatapointUseCaseAsync : KoinComponent,
+    BaseUseCaseAsync<Nothing, Unit>() {
+    private val repo: GeoTrackingRepository by inject()
+    override suspend fun run(): Response<Unit> {
+        return repo.uploadAllGeoTrackingDatapointReadyForUpload()
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/drivelogin/DriveLoginViewModel.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/ui/drivelogin/DriveLoginViewModel.kt
@@ -225,7 +225,7 @@ class DriveLoginViewModel(override val eventsDispatcher: EventsDispatcher<DriveL
                 _userCredentials.postValue(SuccessUserCredentials(response))
                 // TODO: temporary. In the future this will probably happen in a non login related model,
                 // on a click of a button or something
-                setupRemoteDirectory("herdr_raw", listOf("tag0"))
+                setupRemoteDirectory("herdr_raw", listOf("herdr"))
             }
             is Response.Error ->
                 _userCredentials.postValue(ErrorUserCredentials(response))

--- a/app/src/commonMain/sqldelight/com/ludoscity/herdr/common/data/AnalTrackingDatapoint.sq
+++ b/app/src/commonMain/sqldelight/com/ludoscity/herdr/common/data/AnalTrackingDatapoint.sq
@@ -34,6 +34,9 @@ SELECT * FROM analTrackingDatapoint WHERE id = ?;
 selectAll:
 SELECT * FROM analTrackingDatapoint;
 
+selectReadyForUploadAll:
+SELECT * FROM analTrackingDatapoint WHERE upload_completed = 0;
+
 deleteById:
 DELETE FROM analTrackingDatapoint WHERE id = ?;
 

--- a/app/src/commonMain/sqldelight/com/ludoscity/herdr/common/data/GeoTrackingDatapoint.sq
+++ b/app/src/commonMain/sqldelight/com/ludoscity/herdr/common/data/GeoTrackingDatapoint.sq
@@ -30,6 +30,9 @@ SELECT * FROM geoTrackingDatapoint WHERE id = ?;
 selectAll:
 SELECT * FROM geoTrackingDatapoint;
 
+selectReadyForUploadAll:
+SELECT * FROM geoTrackingDatapoint WHERE upload_completed = 0;
+
 deleteById:
 DELETE FROM geoTrackingDatapoint WHERE id = ?;
 

--- a/app/src/main/java/com/ludoscity/herdr/common/Platform.kt
+++ b/app/src/main/java/com/ludoscity/herdr/common/Platform.kt
@@ -19,9 +19,11 @@
 package com.ludoscity.herdr.common
 
 import android.os.Build
+import android.util.Base64
 import com.jaredrummler.android.device.DeviceName
 import com.ludoscity.herdr.BuildConfig
 import com.ludoscity.herdr.utils.Utils
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -30,7 +32,8 @@ actual object Platform {
         get() = System.currentTimeMillis()
     actual val nowString: String
         get() = SimpleDateFormat(Utils.getSimpleDateFormatPattern(), Locale.US)
-                .format(Date(System.currentTimeMillis()))
+            .format(Date(System.currentTimeMillis()))
+    //TODO: timestamping of datapoints might show discrepancy between Long epoch and String one?
 
     actual val app_version: String = "Android:${BuildConfig.VERSION_NAME}"
     actual val api_level: Long = Build.VERSION.SDK_INT.toLong()
@@ -39,4 +42,26 @@ actual object Platform {
         get() = Locale.getDefault().language
     actual val country: String
         get() = Locale.getDefault().country
+
+    actual fun toISO8601UTC(timestampString: String): String {
+        val createdAtOriginal = SimpleDateFormat(Utils.getSimpleDateFormatPattern(), Locale.US)
+            .parse(timestampString)
+        return convertToISO8601UTC(createdAtOriginal) ?: ""
+    }
+
+
+    actual fun hashBase64MD5(toHash: ByteArray): String {
+        return Base64.encodeToString(
+            MessageDigest.getInstance("MD5")
+                .digest(toHash),
+            Base64.DEFAULT
+        )
+    }
+
+    private fun convertToISO8601UTC(date: Date?): String? {
+        val tz = TimeZone.getTimeZone("UTC")
+        val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'", Locale.US)
+        df.timeZone = tz
+        return if (date != null) df.format(date) else null
+    }
 }

--- a/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
@@ -41,7 +41,6 @@ class AnalTrackingUploadWorker(appContext: Context, workerParams: WorkerParamete
     private val uploadAllAnalyticsDatapointUseCaseAsync: UploadAllAnalyticsDatapointUseCaseAsync
             by inject()
 
-
     // ASYNC - COROUTINES
     private val coroutineContextTruc: CoroutineContext by inject()
 
@@ -55,21 +54,4 @@ class AnalTrackingUploadWorker(appContext: Context, workerParams: WorkerParamete
             Result.failure()
         }
     }
-
-
-    /*override suspend fun doWork(): Result {
-        // Do the work here--in this case, upload the data
-        Log.i(AnalTrackingUploadWorker::class.java.simpleName, "About to upload analytic table")
-
-        withContext(coroutineContextTruc {
-
-        })
-
-
-        uploadAllAnalyticsDatapointUseCaseAsync.execute()
-
-
-        // Indicate whether the task finished successfully with the Result
-        return Result.success()
-    }*/
 }

--- a/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
@@ -1,0 +1,75 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.data
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.domain.usecase.analytics.UploadAllAnalyticsDatapointUseCaseAsync
+import kotlinx.coroutines.*
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created by F8Full on 2019-06-28.
+ *
+ * Modified by F8Full on 2020-08-15. This file is part of herdr
+ */
+class AnalTrackingUploadWorker(appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    private val uploadAllAnalyticsDatapointUseCaseAsync: UploadAllAnalyticsDatapointUseCaseAsync
+            by inject()
+
+
+    // ASYNC - COROUTINES
+    private val coroutineContextTruc: CoroutineContext by inject()
+
+    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+        // Do the work here--in this case, upload the data
+        Log.i(AnalTrackingUploadWorker::class.java.simpleName, "About to upload analytic table")
+
+        if (uploadAllAnalyticsDatapointUseCaseAsync.execute() is Response.Success) {
+            Result.success()
+        } else {
+            Result.failure()
+        }
+    }
+
+
+    /*override suspend fun doWork(): Result {
+        // Do the work here--in this case, upload the data
+        Log.i(AnalTrackingUploadWorker::class.java.simpleName, "About to upload analytic table")
+
+        withContext(coroutineContextTruc {
+
+        })
+
+
+        uploadAllAnalyticsDatapointUseCaseAsync.execute()
+
+
+        // Indicate whether the task finished successfully with the Result
+        return Result.success()
+    }*/
+}

--- a/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointUploadWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointUploadWorker.kt
@@ -1,0 +1,58 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.data
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.domain.usecase.geotracking.UploadAllGeoTrackingDatapointUseCaseAsync
+import kotlinx.coroutines.*
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Created by F8Full on 2019-06-28.
+ *
+ * Modified by F8Full on 2020-08-15. This file is part of herdr
+ */
+class GeoTrackingUploadWorker(appContext: Context, workerParams: WorkerParameters) :
+    CoroutineWorker(appContext, workerParams), KoinComponent {
+
+    private val uploadAllGeoTrackingDatapointUseCaseAsync: UploadAllGeoTrackingDatapointUseCaseAsync
+            by inject()
+
+
+    // ASYNC - COROUTINES
+    private val coroutineContextTruc: CoroutineContext by inject()
+
+    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+        // Do the work here--in this case, upload the data
+        Log.i(AnalTrackingUploadWorker::class.java.simpleName, "About to upload geolocation table")
+
+        if (uploadAllGeoTrackingDatapointUseCaseAsync.execute() is Response.Success) {
+            Result.success()
+        } else {
+            Result.failure()
+        }
+    }
+}

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -29,8 +29,10 @@ import com.fondesa.kpermissions.extension.listeners
 import com.fondesa.kpermissions.extension.permissionsBuilder
 import com.ludoscity.herdr.R
 import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository.Companion.UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME
+import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository.Companion.UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
 import com.ludoscity.herdr.data.AnalTrackingUploadWorker
+import com.ludoscity.herdr.data.GeoTrackingUploadWorker
 import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
 import com.ludoscity.herdr.databinding.ActivityHerdrBinding
 import com.ludoscity.herdr.utils.startServiceForeground
@@ -77,16 +79,30 @@ class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
                         .setInitialDelay(5, TimeUnit.SECONDS)
                         .build()
 
+                val uploadGeoRequest =
+                    PeriodicWorkRequestBuilder<GeoTrackingUploadWorker>(15, TimeUnit.MINUTES)
+                        .setConstraints(constraints)
+                        .setInitialDelay(10, TimeUnit.SECONDS)
+                        .build()
+
                 workManager.enqueueUniquePeriodicWork(
                     UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME,
                     ExistingPeriodicWorkPolicy.KEEP,
                     uploadAnalRequest
+                )
+
+                workManager.enqueueUniquePeriodicWork(
+                    UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    uploadGeoRequest
                 )
             } else {
                 stopService(intentFor<TransitionRecognitionService>())
 
                 Log.d("TAG", "Cancelling analytics uploading recurring task")
                 workManager.cancelUniqueWork(UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME)
+                Log.d("TAG", "Cancelling geolocation uploading recurring task")
+                workManager.cancelUniqueWork(UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME)
             }
         }
 

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -21,18 +21,23 @@ package com.ludoscity.herdr.ui.main
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
+import androidx.work.*
 import com.fondesa.kpermissions.extension.listeners
 import com.fondesa.kpermissions.extension.permissionsBuilder
 import com.ludoscity.herdr.R
+import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository.Companion.UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
+import com.ludoscity.herdr.data.AnalTrackingUploadWorker
 import com.ludoscity.herdr.data.transrecognition.TransitionRecognitionService
 import com.ludoscity.herdr.databinding.ActivityHerdrBinding
 import com.ludoscity.herdr.utils.startServiceForeground
 import dev.icerock.moko.mvvm.MvvmActivity
 import dev.icerock.moko.mvvm.createViewModelFactory
 import org.jetbrains.anko.intentFor
+import java.util.concurrent.TimeUnit
 
 class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
 
@@ -51,13 +56,37 @@ class HerdrActivity : MvvmActivity<ActivityHerdrBinding, HerdrViewModel>() {
         // app already can trac(k)e user activity changes (bike <--> walk <--> ...) and trac(k)e geolocation (GPS)
         // and persist in local db.
         // For now, logging out disconnects both tracking, nothing gets persisted to db
-        viewModel.addLoggedInObserver {
-            it?.let { loggedIn ->
-                if (loggedIn) {
-                    startServiceForeground(intentFor<TransitionRecognitionService>())
-                } else {
-                    stopService(intentFor<TransitionRecognitionService>())
-                }
+        viewModel.addLoggedInObserver { loggedIn ->
+            val workManager = WorkManager.getInstance(applicationContext)
+
+            if (loggedIn == true) {
+                startServiceForeground(intentFor<TransitionRecognitionService>())
+
+                Log.d("TAG", "Setting up upload and purge tasks")
+                //WorkManager task for periodic db upload
+                //https://medium.com/androiddevelopers/workmanager-periodicity-ff35185ff006
+                val constraints = Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+
+                //TODO: intervals should be different in debug and release builds.
+                // Debug upload and purge more frequently
+                val uploadAnalRequest =
+                    PeriodicWorkRequestBuilder<AnalTrackingUploadWorker>(1, TimeUnit.HOURS)
+                        .setConstraints(constraints)
+                        .setInitialDelay(5, TimeUnit.SECONDS)
+                        .build()
+
+                workManager.enqueueUniquePeriodicWork(
+                    UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    uploadAnalRequest
+                )
+            } else {
+                stopService(intentFor<TransitionRecognitionService>())
+
+                Log.d("TAG", "Cancelling analytics uploading recurring task")
+                workManager.cancelUniqueWork(UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME)
             }
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ buildscript {
         securityCryptoVersion = "1.0.0-rc02"
         serializerVersion = "0.20.0"
         sqlDelightVersion = "1.4.0"
+        workVersion = "2.4.0"
     }
     dependencies {
         classpath "com.android.tools.build:gradle:$gradleVersion"


### PR DESCRIPTION
#### Description

This PR contains required changes for the Android app to regularly upload analytics and geotracking data

Common
- extend network interface to support file upload
- extend both GeoLocation and Analytics repositories to expose a way to select all non uploaded db rows and upload them as json files

Android
- add worker classes extending CoroutineWorker
- enqueue periodic task using said workers when login is detected (this is temporary)

Result:
![image](https://user-images.githubusercontent.com/416651/90325855-f0e1e280-df4e-11ea-980f-59c4d60edb27.png)

