### PR TITLE
Bugfix for #21 & #22 -- Add repo constructable from background thread

### DIFF
--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/HeadlessRepository.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/data/repository/HeadlessRepository.kt
@@ -1,0 +1,216 @@
+/*
+ *     Copyright (c) 2020. f8full https://github.com/f8full
+ *     Herdr is a privacy conscious multiplatform mobile data collector
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.ludoscity.herdr.common.data.repository
+
+import co.touchlab.kermit.Kermit
+import com.ludoscity.herdr.common.base.Response
+import com.ludoscity.herdr.common.data.SecureDataStore
+import com.ludoscity.herdr.common.data.database.HerdrDatabase
+import com.ludoscity.herdr.common.data.database.dao.AnalTrackingDatapointDao
+import com.ludoscity.herdr.common.data.database.dao.GeoTrackingDatapointDao
+import com.ludoscity.herdr.common.data.network.INetworkDataPipe
+import com.ludoscity.herdr.common.data.network.cozy.AnalTrackingUploadRequestBody
+import com.ludoscity.herdr.common.data.network.cozy.GeoTrackingUploadRequestBody
+import io.ktor.utils.io.errors.IOException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import org.koin.core.parameter.parametersOf
+
+// this repo can be constructed in an Android background thread context. It does not expose any LiveData or anything,
+//hence the headless denomination.
+// it came to be as a fix for background CoroutineWorker on the Android platform would fail because repositories
+//exposing Moko mvvn (Mutable)LiveData can't be constructed on a background thread
+class HeadlessRepository : KoinComponent {
+
+    companion object {
+        const val UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME = "herdr-upload-geo-worker"
+        const val PURGE_GEO_PERIODIC_WORKER_UNIQUE_NAME = "herdr-purge-geo-worker"
+        const val UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME = "herdr-upload-anal-worker"
+        const val PURGE_ANAL_PERIODIC_WORKER_UNIQUE_NAME = "herdr-purge-anal-worker"
+    }
+
+    private val log: Kermit by inject { parametersOf("HeadlessRepository") }
+
+    private val herdrDb: HerdrDatabase by inject()
+    private val networkDataPipe: INetworkDataPipe by inject()
+    private val secureDataStore: SecureDataStore by inject()
+
+
+    suspend fun uploadAllGeoTrackingDatapointReadyForUpload(): Response<Unit> {
+        val geoTrackingDao = GeoTrackingDatapointDao(herdrDb)
+        val allToUpload = geoTrackingDao.selectReadyForUploadAll()
+
+        val stackBase = secureDataStore.retrieveString(
+            LoginRepository.authClientRegistrationBaseUrlStoreKey
+        )
+
+        val cloudDirectoryId = secureDataStore.retrieveString(
+            LoginRepository.cloudDirectoryId
+        )
+
+        return if (allToUpload.isEmpty()) {
+            log.i { "No GeoTracking records to upload, implicit success of uploading task" }
+            Response.Success(Unit)
+        } else if (stackBase == null) {
+            log.w { "No stackbase URL, aborting upload" }
+            Response.Error(IOException("No stackbase URL, aborting upload"))
+        } else if (cloudDirectoryId == null) {
+            log.w { "No cloudDirectoryId, aborting upload" }
+            Response.Error(IOException("No cloudDirectoryId, aborting upload"))
+        } else {
+            log.i { "About to upload ${allToUpload.size} geolocation records" }
+
+            var atLeastOneError = false
+
+            allToUpload.forEach {
+                val networkReply = networkDataPipe.postFile(
+                    stackBase,
+                    cloudDirectoryId,
+                    "${it.timestamp}_GEOLOCATION.json",
+                    listOf("herdr", "geolocation"),
+                    Json(JsonConfiguration.Stable).stringify(
+                        GeoTrackingUploadRequestBody.serializer(),
+                        GeoTrackingUploadRequestBody(
+                            it.timestamp_epoch,
+                            it.altitude,
+                            it.accuracy_horizontal_meters,
+                            it.accuracy_vertical_meters,
+                            it.latitude,
+                            it.longitude,
+                            it.timestamp
+                        )
+                    ),
+                    it.timestamp
+                )
+
+                when (networkReply) {
+                    is Response.Success -> {
+                        log.d { "Upload success, flagged geolocation record: ${it.timestamp} for deletion" }
+                        geoTrackingDao.updateUploadCompleted(it.id)
+                    }
+                    is Response.Error -> {
+                        if (networkReply.code == 409) {
+                            log.i { "Recovered from 409, flagged geolocation record: ${it.timestamp} for deletion" }
+                            geoTrackingDao.updateUploadCompleted(it.id)
+                        } else {
+                            atLeastOneError = true
+                        }
+                    }
+                }
+            }
+
+            if (atLeastOneError) {
+                Response.Error(IOException("Some error happened during the Geolocation upload process"))
+            } else {
+                Response.Success(Unit)
+            }
+        }
+    }
+
+    suspend fun uploadAllAnalTrackingDatapointReadyForUpload(): Response<Unit> {
+        val analTrackingDao = AnalTrackingDatapointDao(herdrDb)
+        val allToUpload = analTrackingDao.selectReadyForUploadAll()
+
+        val stackBase = secureDataStore.retrieveString(
+            LoginRepository.authClientRegistrationBaseUrlStoreKey
+        )
+
+        val cloudDirectoryId = secureDataStore.retrieveString(
+            LoginRepository.cloudDirectoryId
+        )
+
+        return if (allToUpload.isEmpty()) {
+            log.i { "No Analytics to upload, implicit success of uploading task" }
+            Response.Success(Unit)
+        } else if (stackBase == null) {
+            log.w { "No stackbase URL, aborting upload" }
+            Response.Error(IOException("No stackbase URL, aborting upload"))
+        } else if (cloudDirectoryId == null) {
+            log.w { "No cloudDirectoryId, aborting upload" }
+            Response.Error(IOException("No cloudDirectoryId, aborting upload"))
+        } else {
+            log.i { "About to upload ${allToUpload.size} analytics records" }
+
+            var atLeastOneError = false
+
+            allToUpload.forEach {
+                val networkReply = networkDataPipe.postFile(
+                    stackBase,
+                    cloudDirectoryId,
+                    "${it.timestamp}_ANALYTICS.json",
+                    listOf("herdr", "analytics"),
+                    Json(JsonConfiguration.Stable).stringify(
+                        AnalTrackingUploadRequestBody.serializer(),
+                        AnalTrackingUploadRequestBody(
+                            it.timestamp_epoch,
+                            it.app_version,
+                            it.api_level,
+                            it.device_model,
+                            it.language,
+                            it.country,
+                            it.battery_charge_percentage,
+                            it.description,
+                            it.timestamp
+                        )
+                    ),
+                    it.timestamp
+                )
+
+                when (networkReply) {
+                    is Response.Success -> {
+                        log.d { "Upload success, flagged analytics record: ${it.timestamp} for deletion" }
+                        analTrackingDao.updateUploadCompleted(it.id)
+                    }
+                    is Response.Error -> {
+                        if (networkReply.code == 409) {
+                            log.i { "Recovered from 409, flagged analytics record: ${it.timestamp} for deletion" }
+                            analTrackingDao.updateUploadCompleted(it.id)
+                        } else {
+                            atLeastOneError = true
+                        }
+                    }
+                }
+            }
+
+            if (atLeastOneError) {
+                Response.Error(IOException("Some error happened during the Analytics upload process"))
+            } else {
+                Response.Success(Unit)
+            }
+        }
+    }
+
+    suspend fun purgeAllGeoTrackingDatapointAlreadyUploaded(): Response<Unit> {
+        val geoTrackingDao = GeoTrackingDatapointDao(herdrDb)
+        geoTrackingDao.deleteUploadedAll()
+        log.i { "Geolocation table was purged with success of rows already uploaded" }
+        log.i { "${geoTrackingDao.selectReadyForUploadAll().size} Geolocation records are ready for upload" }
+        return Response.Success(Unit)
+    }
+
+    suspend fun purgeAllAnalTrackingDatapointAlreadyUploaded(): Response<Unit> {
+        val analTrackingDao = AnalTrackingDatapointDao(herdrDb)
+        analTrackingDao.deleteUploadedAll()
+        log.i { "Analytics table was purged with success of rows already uploaded" }
+        log.i { "${analTrackingDao.selectReadyForUploadAll().size} Analytics records are ready for upload" }
+        return Response.Success(Unit)
+    }
+}

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/di/Koin.kt
@@ -6,6 +6,7 @@ import com.ludoscity.herdr.common.data.network.INetworkDataPipe
 import com.ludoscity.herdr.common.data.network.cozy.CozyCloupApi
 import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
 import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository
 import com.ludoscity.herdr.common.data.repository.LoginRepository
 import com.ludoscity.herdr.common.domain.usecase.analytics.*
 import com.ludoscity.herdr.common.domain.usecase.geotracking.*
@@ -32,6 +33,7 @@ private val coreModule = module {
     single { LoginRepository() }
     single { GeoTrackingRepository() }
     single { AnalTrackingRepository() }
+    single { HeadlessRepository() }
 
     //use case
     single { RegisterAuthClientUseCaseAsync() }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/PurgeAllAnalyticsDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/PurgeAllAnalyticsDatapointUseCaseAsync.kt
@@ -18,14 +18,14 @@
 package com.ludoscity.herdr.common.domain.usecase.analytics
 
 import com.ludoscity.herdr.common.base.Response
-import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
 class PurgeAllAnalyticsDatapointUseCaseAsync : KoinComponent,
     BaseUseCaseAsync<Nothing, Unit>() {
-    private val repo: AnalTrackingRepository by inject()
+    private val repo: HeadlessRepository by inject()
     override suspend fun run(): Response<Unit> {
         return repo.purgeAllAnalTrackingDatapointAlreadyUploaded()
     }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAllAnalyticsDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/analytics/UploadAllAnalyticsDatapointUseCaseAsync.kt
@@ -18,15 +18,14 @@
 package com.ludoscity.herdr.common.domain.usecase.analytics
 
 import com.ludoscity.herdr.common.base.Response
-import com.ludoscity.herdr.common.data.AnalTrackingDatapoint
-import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
 class UploadAllAnalyticsDatapointUseCaseAsync : KoinComponent,
     BaseUseCaseAsync<Nothing, Unit>() {
-    private val repo: AnalTrackingRepository by inject()
+    private val repo: HeadlessRepository by inject()
     override suspend fun run(): Response<Unit> {
         return repo.uploadAllAnalTrackingDatapointReadyForUpload()
     }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/PurgeAllGeoTrackingDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/PurgeAllGeoTrackingDatapointUseCaseAsync.kt
@@ -18,14 +18,14 @@
 package com.ludoscity.herdr.common.domain.usecase.geotracking
 
 import com.ludoscity.herdr.common.base.Response
-import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
 class PurgeAllGeoTrackingDatapointUseCaseAsync : KoinComponent,
     BaseUseCaseAsync<Nothing, Unit>() {
-    private val repo: GeoTrackingRepository by inject()
+    private val repo: HeadlessRepository by inject()
     override suspend fun run(): Response<Unit> {
         return repo.purgeAllGeoTrackingDatapointAlreadyUploaded()
     }

--- a/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UploadAllGeoTrackingDatapointUseCaseAsync.kt
+++ b/app/src/commonMain/kotlin/com/ludoscity/herdr/common/domain/usecase/geotracking/UploadAllGeoTrackingDatapointUseCaseAsync.kt
@@ -18,14 +18,14 @@
 package com.ludoscity.herdr.common.domain.usecase.geotracking
 
 import com.ludoscity.herdr.common.base.Response
-import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository
 import com.ludoscity.herdr.common.domain.usecase.base.BaseUseCaseAsync
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
 class UploadAllGeoTrackingDatapointUseCaseAsync : KoinComponent,
     BaseUseCaseAsync<Nothing, Unit>() {
-    private val repo: GeoTrackingRepository by inject()
+    private val repo: HeadlessRepository by inject()
     override suspend fun run(): Response<Unit> {
         return repo.uploadAllGeoTrackingDatapointReadyForUpload()
     }

--- a/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointPurgeWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointPurgeWorker.kt
@@ -41,10 +41,7 @@ class AnalTrackingPurgeWorker(appContext: Context, workerParams: WorkerParameter
     private val purgeAllAnalyticsDatapointUseCaseAsync: PurgeAllAnalyticsDatapointUseCaseAsync
             by inject()
 
-    // ASYNC - COROUTINES
-    private val coroutineContextTruc: CoroutineContext by inject()
-
-    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         // Do the work here--in this case, purge the data
         Log.i(AnalTrackingPurgeWorker::class.java.simpleName, "About to purge analytic table")
 

--- a/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/AnalDatapointUploadWorker.kt
@@ -41,10 +41,7 @@ class AnalTrackingUploadWorker(appContext: Context, workerParams: WorkerParamete
     private val uploadAllAnalyticsDatapointUseCaseAsync: UploadAllAnalyticsDatapointUseCaseAsync
             by inject()
 
-    // ASYNC - COROUTINES
-    private val coroutineContextTruc: CoroutineContext by inject()
-
-    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         // Do the work here--in this case, upload the data
         Log.i(AnalTrackingUploadWorker::class.java.simpleName, "About to upload analytic table")
 

--- a/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointPurgeWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointPurgeWorker.kt
@@ -41,10 +41,7 @@ class GeoTrackingPurgeWorker(appContext: Context, workerParams: WorkerParameters
     private val purgeAllGeoTrackingDatapointUseCaseAsync: PurgeAllGeoTrackingDatapointUseCaseAsync
             by inject()
 
-    // ASYNC - COROUTINES
-    private val coroutineContextTruc: CoroutineContext by inject()
-
-    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         // Do the work here--in this case, purge the data
         Log.i(GeoTrackingPurgeWorker::class.java.simpleName, "About to purge geolocation table")
 

--- a/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointUploadWorker.kt
+++ b/app/src/main/java/com/ludoscity/herdr/data/GeoDatapointUploadWorker.kt
@@ -41,11 +41,7 @@ class GeoTrackingUploadWorker(appContext: Context, workerParams: WorkerParameter
     private val uploadAllGeoTrackingDatapointUseCaseAsync: UploadAllGeoTrackingDatapointUseCaseAsync
             by inject()
 
-
-    // ASYNC - COROUTINES
-    private val coroutineContextTruc: CoroutineContext by inject()
-
-    override suspend fun doWork(): Result = withContext(coroutineContextTruc) {
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         // Do the work here--in this case, upload the data
         Log.i(GeoTrackingUploadWorker::class.java.simpleName, "About to upload geolocation table")
 

--- a/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
+++ b/app/src/main/java/com/ludoscity/herdr/ui/main/HerdrActivity.kt
@@ -28,10 +28,10 @@ import androidx.work.*
 import com.fondesa.kpermissions.extension.listeners
 import com.fondesa.kpermissions.extension.permissionsBuilder
 import com.ludoscity.herdr.R
-import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository.Companion.PURGE_ANAL_PERIODIC_WORKER_UNIQUE_NAME
-import com.ludoscity.herdr.common.data.repository.AnalTrackingRepository.Companion.UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME
-import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository.Companion.PURGE_GEO_PERIODIC_WORKER_UNIQUE_NAME
-import com.ludoscity.herdr.common.data.repository.GeoTrackingRepository.Companion.UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository.Companion.PURGE_ANAL_PERIODIC_WORKER_UNIQUE_NAME
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository.Companion.PURGE_GEO_PERIODIC_WORKER_UNIQUE_NAME
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository.Companion.UPLOAD_ANAL_PERIODIC_WORKER_UNIQUE_NAME
+import com.ludoscity.herdr.common.data.repository.HeadlessRepository.Companion.UPLOAD_GEO_PERIODIC_WORKER_UNIQUE_NAME
 import com.ludoscity.herdr.common.ui.main.HerdrViewModel
 import com.ludoscity.herdr.data.AnalTrackingPurgeWorker
 import com.ludoscity.herdr.data.AnalTrackingUploadWorker


### PR DESCRIPTION
#### Description
closes #21 
closes #22 

This PR contains changes so that regular data upload and regular purge don't start failing in the background after the app main interface hasn't be brought to foreground in a while. An extra issue is also fixed regarding duplication of CoroutineScope.
